### PR TITLE
Adds one line description and key queries in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hypertrace Core GraphQL
-
+Hypertrace Core GraphQL service serves the GraphQL API which will be used by Hypertrace Core UI.
 
 ## Testing
 
@@ -12,4 +12,166 @@
 ## Ports
 
 GraphQL Service runs on port 23431 at `/graphql` by default
+
+
+## Queries
+Here are some of the important GraphQL queries:
+
+### 1. Get all traces in provided time range
+
+```graphql
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
+'{
+  traces(
+    type: API_TRACE
+    between: {
+      startTime: "2015-01-01T00:00:00.000Z"
+      endTime: "2025-01-01T00:00:00.000Z"
+    }
+  ) {
+    results {
+      id
+    }
+  }
+}'
+```
+
+### 2. Find trace using TraceID
+
+```graphql
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+'{
+  traces(
+    type: API_TRACE
+    between: {
+      startTime: "2015-01-01T00:00:00.000Z"
+      endTime: "2025-01-01T00:00:00.000Z"
+    }
+    filterBy: [
+      {
+        operator: EQUALS
+        value: "348bae39282251a5"
+        type: ID
+        idType: API_TRACE
+      }
+    ]
+  ) {
+    results {
+      id
+      apiName: attribute(key: "apiName") 
+    }
+  }
+}'
+```
+
+### 3. Get all services your application is using
+
+```graphql
+curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: SERVICE 
+    between: {
+      startTime: "2015-01-01T00:00:00Z"
+      endTime: "2025-01-01T00:00:00Z"
+    }
+    offset: 0
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+    }
+    total
+  }
+}'
+```
+
+### 4. Get all backends your application is using
+
+```graphql
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: BACKEND
+    between: {
+      startTime: "2015-01-01T00:00:00Z"
+      endTime: "2025-01-01T00:00:00Z"
+    }
+    offset: 0
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+    }
+    total
+  }
+}'
+```
+
+### 5. Get all API's your application is using
+
+```graphql
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: API
+    between: {
+      startTime: "2015-01-01T00:00:00Z"
+      endTime: "2025-01-01T00:00:00Z"
+    }
+    offset: 0
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+    }
+    total
+  }
+}'
+```
+
+### 6. Get service and backend dependency graph
+
+```graphql
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: SERVICE
+    limit: 100
+    between: {
+      startTime: "2015-01-01T00:00:00.000Z"
+      endTime: "2025-01-01T00:00:00.000Z"
+    }
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+      outgoingEdges_SERVICE: outgoingEdges(neighborType: SERVICE) {
+        results {
+          neighbor {
+            id
+            name: attribute(key: "name")
+          }
+        }
+      }
+      outgoingEdges_BACKEND: outgoingEdges(neighborType: BACKEND) {
+        results {
+          neighbor {
+            id
+            name: attribute(key: "name")
+          }
+        }
+      }
+      incomingEdges_SERVICE: incomingEdges(neighborType: SERVICE) {
+        results {
+          neighbor {
+            id
+            name: attribute(key: "name")
+          }
+        }
+      }
+    }
+  }
+}'
+```
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Hypertrace Core GraphQL service serves the GraphQL API which will be used by Hyp
 
 GraphQL Service runs on port 23431 at `/graphql` by default
 
-
 ## Queries
 Here are some of the important GraphQL queries:
 
 ### 1. Get all traces in provided time range
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 '{
   traces(
     type: API_TRACE
+    limit: 10
     between: {
       startTime: "2015-01-01T00:00:00.000Z"
       endTime: "2025-01-01T00:00:00.000Z"
@@ -39,7 +39,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 ### 2. Find trace using TraceID
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   traces(
     type: API_TRACE
@@ -67,7 +67,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
 ### 3. Get all services your application is using
 
 ```graphql
-curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE 
@@ -78,7 +78,6 @@ curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d
     offset: 0
   ) {
     results {
-      id
       name: attribute(key: "name")
     }
     total
@@ -89,7 +88,7 @@ curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d
 ### 4. Get all backends your application is using
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: BACKEND
@@ -100,7 +99,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
     offset: 0
   ) {
     results {
-      id
       name: attribute(key: "name")
     }
     total
@@ -111,7 +109,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
 ### 5. Get all API's your application is using
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: API
@@ -122,7 +120,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
     offset: 0
   ) {
     results {
-      id
       name: attribute(key: "name")
     }
     total
@@ -133,7 +130,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
 ### 6. Get service and backend dependency graph
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE
@@ -149,7 +146,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
       outgoingEdges_SERVICE: outgoingEdges(neighborType: SERVICE) {
         results {
           neighbor {
-            id
             name: attribute(key: "name")
           }
         }
@@ -157,7 +153,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
       outgoingEdges_BACKEND: outgoingEdges(neighborType: BACKEND) {
         results {
           neighbor {
-            id
             name: attribute(key: "name")
           }
         }
@@ -165,7 +160,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
       incomingEdges_SERVICE: incomingEdges(neighborType: SERVICE) {
         results {
           neighbor {
-            id
             name: attribute(key: "name")
           }
         }
@@ -174,4 +168,3 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
   }
 }'
 ```
-


### PR DESCRIPTION
- Added one line description for GraphQL service.
- Added queries section which lists key queries across main screens including:
   - Get all traces in provided time range
   - Find trace using TraceID
   - Get all services your application is using
   - Get all backends your application is using
   - Get all API's your application is using
   - Get service and backend dependency graph