### PR TITLE
fix: NPE due to service name getter override

### DIFF
--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/GraphQlService.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/GraphQlService.java
@@ -92,9 +92,4 @@ public class GraphQlService extends PlatformService {
   public boolean healthCheck() {
     return true;
   }
-
-  @Override
-  public String getServiceName() {
-    return this.graphQlServiceConfig.getServiceName();
-  }
 }


### PR DESCRIPTION
First observed after updating platform service framework dependency