### PR TITLE
Adds Time Scalar

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/CommonSchemaFragment.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/CommonSchemaFragment.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import org.hypertrace.core.graphql.common.schema.typefunctions.AttributeScopeDynamicEnum;
 import org.hypertrace.core.graphql.common.schema.typefunctions.DateTimeScalar;
+import org.hypertrace.core.graphql.common.schema.typefunctions.TimeScalar;
 import org.hypertrace.core.graphql.common.schema.typefunctions.UnknownScalar;
 import org.hypertrace.core.graphql.spi.schema.GraphQlSchemaFragment;
 
@@ -14,15 +15,18 @@ class CommonSchemaFragment implements GraphQlSchemaFragment {
   private final DateTimeScalar dateTimeScalar;
   private final UnknownScalar unknownScalar;
   private final AttributeScopeDynamicEnum attributeScopeDynamicEnum;
+  private final TimeScalar timeScalar;
 
   @Inject
   CommonSchemaFragment(
       DateTimeScalar dateTimeScalar,
       UnknownScalar unknownScalar,
-      AttributeScopeDynamicEnum attributeScopeDynamicEnum) {
+      AttributeScopeDynamicEnum attributeScopeDynamicEnum,
+      TimeScalar timeScalar) {
     this.dateTimeScalar = dateTimeScalar;
     this.unknownScalar = unknownScalar;
     this.attributeScopeDynamicEnum = attributeScopeDynamicEnum;
+    this.timeScalar = timeScalar;
   }
 
   @Override
@@ -33,6 +37,10 @@ class CommonSchemaFragment implements GraphQlSchemaFragment {
   @Nonnull
   @Override
   public List<TypeFunction> typeFunctions() {
-    return List.of(this.unknownScalar, this.dateTimeScalar, this.attributeScopeDynamicEnum);
+    return List.of(
+        this.unknownScalar,
+        this.dateTimeScalar,
+        this.attributeScopeDynamicEnum,
+        this.timeScalar);
   }
 }

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/TimeScalar.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/TimeScalar.java
@@ -1,0 +1,81 @@
+package org.hypertrace.core.graphql.common.schema.typefunctions;
+
+import graphql.GraphqlErrorException;
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.annotations.processor.typeFunctions.TypeFunction;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+import java.lang.reflect.AnnotatedType;
+import java.time.DateTimeException;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.function.Function;
+
+/**
+ * Graphql Scalar for Time without date or timezone
+ */
+public class TimeScalar implements TypeFunction {
+
+  private static final GraphQLScalarType TIME_SCALAR =
+      GraphQLScalarType.newScalar()
+          .name("Time")
+          .description("An ISO-8601 formatted Time Scalar")
+          .coercing(
+              new Coercing<LocalTime, String>() {
+                @Override
+                public String serialize(Object fetcherResult) throws CoercingSerializeException {
+                  return toLocalTime(fetcherResult, CoercingSerializeException::new).toString();
+                }
+
+                @Override
+                public LocalTime parseValue(Object input) throws CoercingParseValueException {
+                  return toLocalTime(input, CoercingParseValueException::new);
+                }
+
+                @Override
+                public LocalTime parseLiteral(Object input) throws CoercingParseLiteralException {
+                  return toLocalTime(input, CoercingParseLiteralException::new);
+                }
+
+                private <E extends GraphqlErrorException> LocalTime toLocalTime(
+                    Object timeInput, Function<Exception, E> errorWrapper) throws E {
+                  try {
+                    if (timeInput instanceof TemporalAccessor) {
+                      return LocalTime.from((TemporalAccessor) timeInput);
+                    }
+                    if (timeInput instanceof CharSequence) {
+                      return LocalTime.parse((CharSequence) timeInput);
+                    }
+                    if (timeInput instanceof StringValue) {
+                      return LocalTime.parse(((StringValue) timeInput).getValue());
+                    }
+                  } catch (DateTimeException exception) {
+                    throw errorWrapper.apply(exception);
+                  }
+                  throw errorWrapper.apply(
+                      new DateTimeException(
+                          String.format(
+                              "Cannot convert provided format '%s' to LocalTime",
+                              timeInput.getClass().getCanonicalName())));
+                }
+              })
+          .build();
+
+  @Override
+  public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
+    return TemporalAccessor.class.isAssignableFrom(aClass);
+  }
+
+  @Override
+  public GraphQLScalarType buildType(
+      boolean input,
+      Class<?> aClass,
+      AnnotatedType annotatedType,
+      ProcessingElementsContainer container) {
+    return TIME_SCALAR;
+  }
+}

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/TimeScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/TimeScalarTest.java
@@ -1,0 +1,58 @@
+package org.hypertrace.core.graphql.common.schema.scalars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import graphql.language.StringValue;
+import graphql.schema.GraphQLScalarType;
+import java.time.LocalTime;
+import org.hypertrace.core.graphql.common.schema.typefunctions.TimeScalar;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TimeScalarTest {
+
+  private static final String TIME_STRING = "08:30";
+  private static final LocalTime LOCAL_TIME = LocalTime.parse(TIME_STRING);
+  private TimeScalar timeScalar;
+  private GraphQLScalarType timeType;
+
+  @BeforeEach
+  void beforeEach() {
+    this.timeScalar = new TimeScalar();
+    this.timeType =
+        this.timeScalar.buildType(
+            false, null, null, null);
+  }
+
+  @Test
+  void test_canBuildType_compatibleTypes_shouldReturnTrue() {
+    assertTrue(this.timeScalar.canBuildType(LocalTime.class, null));
+  }
+
+  @Test
+  void test_canConvertFromLiteral() {
+    assertEquals(
+        LOCAL_TIME, timeType.getCoercing().parseLiteral(TIME_STRING));
+  }
+
+  @Test
+  void test_canSerialize() {
+    assertEquals(
+        TIME_STRING, timeType.getCoercing().serialize(LOCAL_TIME));
+    assertEquals(
+        TIME_STRING, timeType.getCoercing().serialize(TIME_STRING));
+  }
+
+  @Test
+  void test_canConvertFromValue() {
+    assertEquals(
+        LOCAL_TIME,
+        timeType
+            .getCoercing()
+            .parseValue(StringValue.newStringValue().value(TIME_STRING).build()));
+  }
+}


### PR DESCRIPTION
Supports Time Scalar without Date such as 08:00.
This is useful to specify schedule rather than a temporal date time.