### PR TITLE
draft: timer for getTraces

### DIFF
--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.0")
     api("org.hypertrace.gateway.service:gateway-service-api:0.1.1")
     api("org.hypertrace.core.attribute.service:attribute-service-api:0.6.0")
+    api("org.hypertrace.core.serviceframework:platform-metrics:0.1.15")
 
     api("com.google.inject:guice:4.2.3")
     api("com.graphql-java:graphql-java:14.0")

--- a/hypertrace-core-graphql-trace-schema/build.gradle.kts
+++ b/hypertrace-core-graphql-trace-schema/build.gradle.kts
@@ -16,7 +16,9 @@ dependencies {
   implementation("org.slf4j:slf4j-api")
   implementation("io.reactivex.rxjava3:rxjava")
   implementation("org.hypertrace.gateway.service:gateway-service-api")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics")
   implementation("com.google.protobuf:protobuf-java-util")
+
 
   implementation(project(":hypertrace-core-graphql-context"))
   implementation(project(":hypertrace-core-graphql-grpc-utils"))

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
@@ -3,6 +3,7 @@ package org.hypertrace.core.graphql.trace.dao;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import io.grpc.CallCredentials;
+import io.micrometer.core.instrument.Timer;
 import io.reactivex.rxjava3.core.Single;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -12,10 +13,18 @@ import org.hypertrace.core.graphql.trace.request.TraceRequest;
 import org.hypertrace.core.graphql.trace.schema.TraceResultSet;
 import org.hypertrace.core.graphql.utils.grpc.GraphQlGrpcContextBuilder;
 import org.hypertrace.core.graphql.utils.grpc.GrpcChannelRegistry;
+import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.hypertrace.gateway.service.GatewayServiceGrpc;
 import org.hypertrace.gateway.service.GatewayServiceGrpc.GatewayServiceFutureStub;
 import org.hypertrace.gateway.service.v1.trace.TracesRequest;
 import org.hypertrace.gateway.service.v1.trace.TracesResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @Singleton
 class GatewayServiceTraceDao implements TraceDao {
@@ -24,6 +33,9 @@ class GatewayServiceTraceDao implements TraceDao {
   private final GraphQlGrpcContextBuilder grpcContextBuilder;
   private final GatewayServiceTraceRequestBuilder requestBuilder;
   private final GatewayServiceTraceConverter traceConverter;
+  private static final String TRACE_FETCH_LATENCY = "graphql.trace.fetch.latency";
+  private final ConcurrentMap<String, Timer> tenantToTraceFetchTime = new ConcurrentHashMap<>();
+  private static final Logger LOG = LoggerFactory.getLogger(GatewayServiceTraceDao.class);
 
   @Inject
   GatewayServiceTraceDao(
@@ -46,7 +58,20 @@ class GatewayServiceTraceDao implements TraceDao {
 
   @Override
   public Single<TraceResultSet> getTraces(TraceRequest request) {
-    return this.requestBuilder
+    try {
+      return tenantToTraceFetchTime.computeIfAbsent(
+          request.context().getTenantId().orElse("NOT_AVAILABLE"),
+          tenantId ->
+            PlatformMetricsRegistry.registerTimer(TRACE_FETCH_LATENCY, Map.of("tenantid", tenantId)))
+          .recordCallable(getTracesCallable(request));
+    } catch (Exception e) {
+      LOG.error("Failed to get traces for tenant {}", request.context().getTenantId());
+    }
+    return null;
+  }
+
+  private Callable<Single<TraceResultSet>> getTracesCallable(TraceRequest request) {
+    return () -> this.requestBuilder
         .buildRequest(request)
         .flatMap(serverRequest -> this.makeRequest(request.context(), serverRequest))
         .flatMap(


### PR DESCRIPTION
draft: timer for getTraces

Publish overall graphQL service latency metrics per tenant. 