### PR TITLE
feat: support dynamic id mappings

### DIFF
--- a/hypertrace-core-graphql-attribute-store/build.gradle.kts
+++ b/hypertrace-core-graphql-attribute-store/build.gradle.kts
@@ -11,10 +11,11 @@ dependencies {
 
   implementation("org.slf4j:slf4j-api")
   implementation("io.reactivex.rxjava3:rxjava")
-  implementation("com.google.guava:guava:29.0-jre")
+  implementation("com.google.guava:guava")
 
   implementation("org.hypertrace.core.attribute.service:attribute-service-api")
   implementation(project(":hypertrace-core-graphql-grpc-utils"))
+  implementation(project(":hypertrace-core-graphql-rx-utils"))
 
   annotationProcessor("org.projectlombok:lombok")
   compileOnly("org.projectlombok:lombok")

--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeStoreModule.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeStoreModule.java
@@ -1,7 +1,11 @@
 package org.hypertrace.core.graphql.attributes;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.multibindings.Multibinder;
 import io.grpc.CallCredentials;
+import io.reactivex.rxjava3.core.Scheduler;
+import org.hypertrace.core.graphql.rx.BoundedIoScheduler;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
 import org.hypertrace.core.graphql.utils.grpc.GraphQlGrpcContextBuilder;
 import org.hypertrace.core.graphql.utils.grpc.GrpcChannelRegistry;
@@ -11,9 +15,12 @@ public class AttributeStoreModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(AttributeStore.class).to(CachingAttributeStore.class);
+    Multibinder.newSetBinder(binder(), IdMapping.class);
+    Multibinder.newSetBinder(binder(), IdMappingLoader.class);
     requireBinding(GraphQlServiceConfig.class);
     requireBinding(GraphQlGrpcContextBuilder.class);
     requireBinding(CallCredentials.class);
     requireBinding(GrpcChannelRegistry.class);
+    requireBinding(Key.get(Scheduler.class, BoundedIoScheduler.class));
   }
 }

--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/IdLookup.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/IdLookup.java
@@ -1,30 +1,75 @@
 package org.hypertrace.core.graphql.attributes;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.core.Single;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.hypertrace.core.graphql.context.ContextualCachingKey;
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.core.graphql.rx.BoundedIoScheduler;
 
 @Singleton
 class IdLookup {
 
-  private final ImmutableTable<String, String, String> idTable;
+  private final LoadingCache<ContextualCachingKey, Single<ImmutableTable<String, String, String>>>
+      idMapCache;
+  private final Set<IdMappingLoader> mappingLoaders;
+  private final Scheduler boundedIoScheduler;
 
   @Inject
-  IdLookup(Set<IdMapping> idMappings) {
-    this.idTable =
-        idMappings.stream()
-            .collect(
-                ImmutableTable.toImmutableTable(
-                    IdMapping::containingScope, IdMapping::foreignScope, IdMapping::idAttribute));
+  IdLookup(
+      Set<IdMapping> idMappings,
+      Set<IdMappingLoader> mappingLoaders,
+      @BoundedIoScheduler Scheduler boundedIoScheduler) {
+    this.mappingLoaders =
+        ImmutableSet.<IdMappingLoader>builder()
+            .addAll(mappingLoaders)
+            .add(requestContext -> Observable.fromIterable(idMappings))
+            .build();
+    this.boundedIoScheduler = boundedIoScheduler;
+    this.idMapCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(1000)
+            .expireAfterWrite(15, TimeUnit.MINUTES)
+            .build(CacheLoader.from(this::loadMappingsForContext));
   }
 
-  Optional<String> idKey(String scope) {
-    return this.foreignIdKey(scope, scope);
+  Maybe<String> idKey(GraphQlRequestContext requestContext, String scope) {
+    return this.foreignIdKey(requestContext, scope, scope);
   }
 
-  Optional<String> foreignIdKey(String scope, String foreignScope) {
-    return Optional.ofNullable(this.idTable.get(scope, foreignScope));
+  Maybe<String> foreignIdKey(
+      GraphQlRequestContext requestContext, String scope, String foreignScope) {
+    return this.getOrInvalidate(requestContext)
+        .mapOptional(table -> Optional.ofNullable(table.get(scope, foreignScope)));
+  }
+
+  private Single<ImmutableTable<String, String, String>> loadMappingsForContext(
+      ContextualCachingKey key) {
+    return Observable.fromIterable(this.mappingLoaders)
+        .flatMap(
+            idMappingLoader ->
+                idMappingLoader.loadMappings(key.getContext()).subscribeOn(this.boundedIoScheduler))
+        .collect(
+            ImmutableTable.toImmutableTable(
+                IdMapping::containingScope, IdMapping::foreignScope, IdMapping::idAttribute))
+        .cache();
+  }
+
+  private Single<ImmutableTable<String, String, String>> getOrInvalidate(
+      GraphQlRequestContext context) {
+    return this.idMapCache
+        .getUnchecked(context.getCachingKey())
+        .doOnError(x -> this.idMapCache.invalidate(context.getCachingKey()));
   }
 }

--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/IdMappingLoader.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/IdMappingLoader.java
@@ -1,0 +1,12 @@
+package org.hypertrace.core.graphql.attributes;
+
+import io.reactivex.rxjava3.core.Observable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+
+public interface IdMappingLoader {
+  Observable<IdMapping> loadMappings(GraphQlRequestContext requestContext);
+
+
+}

--- a/hypertrace-core-graphql-attribute-store/src/test/java/org/hypertrace/core/graphql/attributes/IdLookupTest.java
+++ b/hypertrace-core-graphql-attribute-store/src/test/java/org/hypertrace/core/graphql/attributes/IdLookupTest.java
@@ -1,25 +1,111 @@
 package org.hypertrace.core.graphql.attributes;
 
+import static org.hypertrace.core.graphql.attributes.IdMapping.forForeignId;
+import static org.hypertrace.core.graphql.attributes.IdMapping.forId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.Optional;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.Collections;
 import java.util.Set;
+import org.hypertrace.core.graphql.context.ContextualCachingKey;
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.junit.jupiter.api.Test;
 
 class IdLookupTest {
 
   @Test
   void canLookupIds() {
+    GraphQlRequestContext mockContext = this.buildNewMockContext();
     IdLookup idLookup =
         new IdLookup(
             Set.of(
-                IdMapping.forId("SPAN", "s-id"),
-                IdMapping.forId("TRACE", "t-id"),
-                IdMapping.forForeignId("SPAN", "TRACE", "s-t-id")));
+                forId("SPAN", "s-id"),
+                forId("TRACE", "t-id"),
+                forForeignId("SPAN", "TRACE", "s-t-id")),
+            Collections.emptySet(),
+            Schedulers.single());
 
-    assertEquals(Optional.of("s-id"), idLookup.idKey("SPAN"));
-    assertEquals(Optional.of("t-id"), idLookup.idKey("TRACE"));
-    assertEquals(Optional.of("s-t-id"), idLookup.foreignIdKey("SPAN", "TRACE"));
-    assertEquals(Optional.empty(), idLookup.foreignIdKey("TRACE", "SPAN"));
+    assertEquals("s-id", idLookup.idKey(mockContext, "SPAN").blockingGet());
+    assertEquals("t-id", idLookup.idKey(mockContext, "TRACE").blockingGet());
+    assertEquals("s-t-id", idLookup.foreignIdKey(mockContext, "SPAN", "TRACE").blockingGet());
+    assertTrue(idLookup.foreignIdKey(mockContext, "TRACE", "SPAN").isEmpty().blockingGet());
+  }
+
+  @Test
+  void supportsMultipleAsyncLoaders() {
+
+    GraphQlRequestContext mockContext = this.buildNewMockContext();
+
+    IdLookup idLookup =
+        new IdLookup(
+            Set.of(forId("SCOPE_ONE", "1-id")),
+            Set.of(
+                unused ->
+                    Observable.just(
+                        forId("SCOPE_TWO", "2-id"),
+                        forForeignId("SCOPE_TWO", "SCOPE_THREE", "3-id")),
+                unused -> Observable.just(forId("SCOPE_THREE", "3-id"))),
+            Schedulers.single());
+
+    assertEquals("1-id", idLookup.idKey(mockContext, "SCOPE_ONE").blockingGet());
+    assertEquals("2-id", idLookup.idKey(mockContext, "SCOPE_TWO").blockingGet());
+    assertEquals(
+        "3-id", idLookup.foreignIdKey(mockContext, "SCOPE_TWO", "SCOPE_THREE").blockingGet());
+    assertEquals("3-id", idLookup.idKey(mockContext, "SCOPE_THREE").blockingGet());
+    assertTrue(idLookup.idKey(mockContext, "SCOPE_FOUR").isEmpty().blockingGet());
+  }
+
+  @Test
+  void cachesLoaderResults() {
+    GraphQlRequestContext mockContext = this.buildNewMockContext();
+    GraphQlRequestContext otherContext = this.buildNewMockContext();
+    IdMappingLoader mappingLoader = mock(IdMappingLoader.class);
+    when(mappingLoader.loadMappings(mockContext))
+        .thenReturn(Observable.just(forId("SCOPE_ONE", "1-id")));
+    when(mappingLoader.loadMappings(otherContext))
+        .thenReturn(Observable.just(forId("SCOPE_ONE", "1-id-other")));
+    IdLookup idLookup =
+        new IdLookup(Collections.emptySet(), Set.of(mappingLoader), Schedulers.single());
+
+    assertEquals("1-id", idLookup.idKey(mockContext, "SCOPE_ONE").blockingGet());
+    assertEquals("1-id-other", idLookup.idKey(otherContext, "SCOPE_ONE").blockingGet());
+    assertEquals("1-id", idLookup.idKey(mockContext, "SCOPE_ONE").blockingGet());
+    assertEquals("1-id-other", idLookup.idKey(otherContext, "SCOPE_ONE").blockingGet());
+    verify(mappingLoader, times(1)).loadMappings(mockContext);
+    verify(mappingLoader, times(1)).loadMappings(otherContext);
+  }
+
+  @Test
+  void retriesOnError() {
+    GraphQlRequestContext mockContext = this.buildNewMockContext();
+
+    IdMappingLoader mappingLoader = mock(IdMappingLoader.class);
+    when(mappingLoader.loadMappings(mockContext))
+        .thenReturn(Observable.error(IllegalStateException::new));
+    IdLookup idLookup =
+        new IdLookup(Collections.emptySet(), Set.of(mappingLoader), Schedulers.single());
+
+    assertThrows(
+        IllegalStateException.class, idLookup.idKey(mockContext, "SCOPE_ONE")::blockingGet);
+
+    when(mappingLoader.loadMappings(mockContext))
+        .thenReturn(Observable.just(forId("SCOPE_ONE", "1-id")));
+
+    assertEquals("1-id", idLookup.idKey(mockContext, "SCOPE_ONE").blockingGet());
+  }
+
+  private GraphQlRequestContext buildNewMockContext() {
+    ContextualCachingKey mockCachingKey = mock(ContextualCachingKey.class);
+    GraphQlRequestContext mockContext = mock(GraphQlRequestContext.class);
+    when(mockCachingKey.getContext()).thenReturn(mockContext);
+    when(mockContext.getCachingKey()).thenReturn(mockCachingKey);
+    return mockContext;
   }
 }


### PR DESCRIPTION
this change allows id mappings to be added dynamically without
explicitly listing them out in the guice module config. This is meant to
unlock support for features like tenant-scoped entities and dynamically
created entity types.