### PR TITLE
feat: expose if an attribute can be aggregated in metadata

### DIFF
--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeModel.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeModel.java
@@ -16,7 +16,9 @@ public interface AttributeModel {
 
   String units();
 
-  boolean requiresAggregation();
+  boolean onlySupportsGrouping();
+
+  boolean onlySupportsAggregation();
 
   List<AttributeModelMetricAggregationType> supportedMetricAggregationTypes();
 

--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeModelTranslator.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeModelTranslator.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.hypertrace.core.attribute.service.v1.AggregateFunction;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ class AttributeModelTranslator {
               this.convertType(attributeMetadata.getValueKind()),
               attributeMetadata.getUnit(),
               attributeMetadata.getOnlyAggregationsAllowed(),
+              attributeMetadata.getType().equals(AttributeType.METRIC),
               this.convertMetricAggregationTypes(attributeMetadata.getSupportedAggregationsList()),
               attributeMetadata.getGroupable()));
     } catch (Exception e) {

--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/DefaultAttributeModel.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/DefaultAttributeModel.java
@@ -6,7 +6,7 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 @Accessors(fluent = true)
 class DefaultAttributeModel implements AttributeModel {
   String id;
@@ -15,7 +15,8 @@ class DefaultAttributeModel implements AttributeModel {
   String displayName;
   AttributeModelType type;
   String units;
-  boolean requiresAggregation;
+  boolean onlySupportsGrouping;
+  boolean onlySupportsAggregation;
   List<AttributeModelMetricAggregationType> supportedMetricAggregationTypes;
   boolean groupable;
 }

--- a/hypertrace-core-graphql-attribute-store/src/test/java/org/hypertrace/core/graphql/attributes/AttributeModelTranslatorTest.java
+++ b/hypertrace-core-graphql-attribute-store/src/test/java/org/hypertrace/core/graphql/attributes/AttributeModelTranslatorTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AggregateFunction;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ class AttributeModelTranslatorTest {
 
   private AttributeModelTranslator translator;
   private AttributeMetadata metadata;
-  private AttributeModel expectedModel;
+  private DefaultAttributeModel expectedModel;
 
   @BeforeEach
   void beforeEach() {
@@ -26,6 +27,7 @@ class AttributeModelTranslatorTest {
             .setKey("key")
             .setDisplayName("display name")
             .setValueKind(AttributeKind.TYPE_STRING)
+            .setType(AttributeType.ATTRIBUTE)
             .setUnit("unit")
             .setOnlyAggregationsAllowed(true)
             .addAllSupportedAggregations(List.of(AggregateFunction.SUM, AggregateFunction.AVG))
@@ -40,7 +42,8 @@ class AttributeModelTranslatorTest {
             .displayName("display name")
             .type(AttributeModelType.STRING)
             .units("unit")
-            .requiresAggregation(true)
+            .onlySupportsGrouping(true)
+            .onlySupportsAggregation(false)
             .supportedMetricAggregationTypes(
                 List.of(
                     AttributeModelMetricAggregationType.SUM,
@@ -52,6 +55,15 @@ class AttributeModelTranslatorTest {
   @Test
   void canTranslateAttributeModel() {
     assertEquals(Optional.of(this.expectedModel), this.translator.translate(this.metadata));
+  }
+
+  @Test
+  void translatesMetricstoOnlySupportAggregation() {
+    AttributeMetadata metricMetadata =
+        this.metadata.toBuilder().setType(AttributeType.METRIC).build();
+    DefaultAttributeModel expectedMetricModel =
+        this.expectedModel.toBuilder().onlySupportsAggregation(true).build();
+    assertEquals(Optional.of(expectedMetricModel), this.translator.translate(metricMetadata));
   }
 
   @Test
@@ -88,7 +100,7 @@ class AttributeModelTranslatorTest {
             .displayName("display name")
             .type(AttributeModelType.STRING_ARRAY)
             .units("unit")
-            .requiresAggregation(false)
+            .onlySupportsGrouping(false)
             .supportedMetricAggregationTypes(
                 List.of(
                     AttributeModelMetricAggregationType.DISTINCT_COUNT,

--- a/hypertrace-core-graphql-metadata-schema/src/main/java/org/hypertrace/core/graphql/metadata/response/DefaultAttributeMetadata.java
+++ b/hypertrace-core-graphql-metadata-schema/src/main/java/org/hypertrace/core/graphql/metadata/response/DefaultAttributeMetadata.java
@@ -18,7 +18,13 @@ class DefaultAttributeMetadata implements AttributeMetadata {
   String displayName;
   AttributeType type;
   String units;
-  boolean onlyAggregationsAllowed;
+  boolean onlySupportsGrouping;
+  boolean onlySupportsAggregation;
   List<MetricAggregationType> supportedAggregations;
   boolean groupable;
+
+  // TODO remove once removed from the api
+  public boolean onlyAggregationsAllowed() {
+    return this.onlySupportsGrouping();
+  }
 }

--- a/hypertrace-core-graphql-metadata-schema/src/main/java/org/hypertrace/core/graphql/metadata/response/MetadataResponseBuilder.java
+++ b/hypertrace-core-graphql-metadata-schema/src/main/java/org/hypertrace/core/graphql/metadata/response/MetadataResponseBuilder.java
@@ -52,7 +52,8 @@ public class MetadataResponseBuilder {
                     model.displayName(),
                     type,
                     model.units(),
-                    model.requiresAggregation(),
+                    model.onlySupportsGrouping(),
+                    model.onlySupportsAggregation(),
                     aggregations,
                     model.groupable()))
         .cast(AttributeMetadata.class)

--- a/hypertrace-core-graphql-metadata-schema/src/main/java/org/hypertrace/core/graphql/metadata/schema/AttributeMetadata.java
+++ b/hypertrace-core-graphql-metadata-schema/src/main/java/org/hypertrace/core/graphql/metadata/schema/AttributeMetadata.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.graphql.metadata.schema;
 
 import graphql.annotations.annotationTypes.GraphQLDeprecate;
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
@@ -18,6 +19,8 @@ public interface AttributeMetadata {
   String ATTRIBUTE_METADATA_TYPE_NAME = "type";
   String ATTRIBUTE_METADATA_UNITS_NAME = "units";
   String ATTRIBUTE_METADATA_ONLY_AGGREGATIONS_ALLOWED_NAME = "onlyAggregationsAllowed";
+  String ATTRIBUTE_METADATA_ONLY_SUPPORTS_AGGREGATION_NAME = "onlySupportsAggregation";
+  String ATTRIBUTE_METADATA_ONLY_SUPPORTS_GROUPING_NAME = "onlySupportsGrouping";
   String ATTRIBUTE_METADATA_SUPPORTED_AGGREGATIONS_NAME = "supportedAggregations";
   String ATTRIBUTE_METADATA_GROUPABLE_NAME = "groupable";
 
@@ -46,10 +49,25 @@ public interface AttributeMetadata {
   @GraphQLName(ATTRIBUTE_METADATA_UNITS_NAME)
   String units();
 
+  @GraphQLDeprecate
+  @Deprecated
   @GraphQLField
   @GraphQLNonNull
+  @GraphQLDescription("Deprecated. This has been renamed to " + ATTRIBUTE_METADATA_ONLY_SUPPORTS_GROUPING_NAME)
   @GraphQLName(ATTRIBUTE_METADATA_ONLY_AGGREGATIONS_ALLOWED_NAME)
   boolean onlyAggregationsAllowed();
+
+  @GraphQLField
+  @GraphQLNonNull
+  @GraphQLName(ATTRIBUTE_METADATA_ONLY_SUPPORTS_GROUPING_NAME)
+  @GraphQLDescription("Signifies an attribute is only available in a grouped query")
+  boolean onlySupportsGrouping();
+
+  @GraphQLField
+  @GraphQLNonNull
+  @GraphQLName(ATTRIBUTE_METADATA_ONLY_SUPPORTS_AGGREGATION_NAME)
+  @GraphQLDescription("Signifies an attribute is only available as an aggregation on all queries")
+  boolean onlySupportsAggregation();
 
   @GraphQLField
   @GraphQLNonNull

--- a/hypertrace-core-graphql-metadata-schema/src/test/java/org/hypertrace/core/graphql/metadata/response/MetadataResponseBuilderTest.java
+++ b/hypertrace-core-graphql-metadata-schema/src/test/java/org/hypertrace/core/graphql/metadata/response/MetadataResponseBuilderTest.java
@@ -46,7 +46,8 @@ class MetadataResponseBuilderTest {
     when(mockModel.type()).thenReturn(AttributeModelType.STRING);
     when(mockModel.units()).thenReturn("unit");
     when(mockModel.groupable()).thenReturn(true);
-    when(mockModel.requiresAggregation()).thenReturn(true);
+    when(mockModel.onlySupportsGrouping()).thenReturn(false);
+    when(mockModel.onlySupportsAggregation()).thenReturn(true);
     when(mockModel.supportedMetricAggregationTypes())
         .thenReturn(
             List.of(
@@ -71,7 +72,8 @@ class MetadataResponseBuilderTest {
                 .displayName("display name")
                 .type(AttributeType.STRING)
                 .units("unit")
-                .onlyAggregationsAllowed(true)
+                .onlySupportsGrouping(false)
+                .onlySupportsAggregation(true)
                 .supportedAggregations(
                     List.of(MetricAggregationType.SUM, MetricAggregationType.AVG))
                 .groupable(true)
@@ -97,7 +99,8 @@ class MetadataResponseBuilderTest {
                 .displayName("display name")
                 .type(AttributeType.STRING)
                 .units("unit")
-                .onlyAggregationsAllowed(true)
+                .onlySupportsGrouping(false)
+                .onlySupportsAggregation(true)
                 .supportedAggregations(List.of(MetricAggregationType.AVG))
                 .groupable(true)
                 .build()),


### PR DESCRIPTION
## Description
This change exposes a new piece of metadata `onlySupportsAggregation`) whether an attribute must be aggregated in its metadata. There was an existing attribute with an extremely confusing name and different meaning, `onlyAggregationsAllowed` that was deprecated and instead renamed to a more accurate name, `onlySupportsGrouping`. 

The prior attribute (now known as `onlySupportsGrouping`) indicates an attribute is only available in a grouped query (which also implicitly means an aggregation). The new attribute (`onlySupportsAggregation`) indicates an attribute requires an aggregation in any query, whether grouped or row level. Descriptions have been added to reflect this.

This will be used in the UI to programmatically build table columns based on available attribute metadata.

### Testing
Unit tests were added for the various related conversions. Also functionally verified by running the graphql server with live data.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
GraphQL schema has been updated with the descriptions and deprecations of the new schema elements.