### PR TITLE
fix: support a different arg name for plural args

### DIFF
--- a/hypertrace-core-graphql-deserialization/src/main/java/org/hypertrace/core/graphql/deserialization/ArgumentDeserializationConfig.java
+++ b/hypertrace-core-graphql-deserialization/src/main/java/org/hypertrace/core/graphql/deserialization/ArgumentDeserializationConfig.java
@@ -8,6 +8,10 @@ public interface ArgumentDeserializationConfig {
 
   String getArgumentKey();
 
+  default String getListArgumentKey() {
+    return getArgumentKey();
+  }
+
   Class<?> getArgumentSchema();
 
   default List<Module> jacksonModules() {
@@ -15,6 +19,11 @@ public interface ArgumentDeserializationConfig {
   }
 
   static ArgumentDeserializationConfig forPrimitive(String argKey, Class<?> argSchema) {
-    return new SimpleArgumentDeserializationConfig(argKey, argSchema);
+    return forPrimitive(argKey, argKey, argSchema);
+  }
+
+  static ArgumentDeserializationConfig forPrimitive(
+      String argKey, String listArgKey, Class<?> argSchema) {
+    return new SimpleArgumentDeserializationConfig(argKey, listArgKey, argSchema);
   }
 }

--- a/hypertrace-core-graphql-deserialization/src/main/java/org/hypertrace/core/graphql/deserialization/SimpleArgumentDeserializationConfig.java
+++ b/hypertrace-core-graphql-deserialization/src/main/java/org/hypertrace/core/graphql/deserialization/SimpleArgumentDeserializationConfig.java
@@ -5,5 +5,6 @@ import lombok.Value;
 @Value
 class SimpleArgumentDeserializationConfig implements ArgumentDeserializationConfig {
   String argumentKey;
+  String listArgumentKey;
   Class<?> argumentSchema;
 }


### PR DESCRIPTION
## Description
Support using a different argument name when deserializing a list of arguments vs a single arg


### Testing
Updated unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
