### PR TITLE
ci: fix snyk args to match all configs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,21 +4,21 @@ on:
     branches:
       - main
   pull_request_target:
-    branches: 
+    branches:
       - main
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
-      
+
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
 
@@ -36,10 +36,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_READ_USER }}
           password: ${{ secrets.DOCKERHUB_READ_TOKEN }}
-      
+
       - name: Build with Gradle
         uses: hypertrace/github-actions/gradle@main
-        with: 
+        with:
           args: build dockerBuildImages
 
   validate-helm-charts:
@@ -58,7 +58,7 @@ jobs:
   snyk-scan:
     runs-on: ubuntu-20.04
     steps:
-    # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
@@ -68,6 +68,6 @@ jobs:
       - name: Setup snyk
         uses: snyk/actions/setup@0.3.0
       - name: Snyk test
-        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk --configuration-matching='^runtimeClasspath$'
+        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Description
Remove config filter for graphql - not needed here. It was an optimization (and avoided enforcing extra strict checks on test deps), but looks like snyk requires it match every project. Because graphql uses a platform project (which apparently snyk doesn't have built in support for) it has a project that does not have its own runtimeClasspath. 

I also tried changing the regex to make it less strict, but even something like `runtime` or `.*runtime.*` is not matching:
```
> Matching configurations not found: runtime, available configurations for project project ':hypertrace-core-graphql-platform': [api, apiElements, archives, classpath, default, enforcedApiElements, enforcedRu
ntimeElements, runtime, runtimeElements]
```
### Testing
Ran snyk locally successfully
