### PR TITLE
fix: publish for docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: publish docker image
         uses: hypertrace/github-actions/gradle@main
         with: 
-          args: publish dockerPushImages
+          args: dockerPushImages
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_PUBLISH_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Description
removes publish from gradle publish as this repo doesn't have publish. 
