### PR TITLE
feat: add duration scalar support

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/CommonSchemaFragment.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/CommonSchemaFragment.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import org.hypertrace.core.graphql.common.schema.typefunctions.AttributeScopeDynamicEnum;
 import org.hypertrace.core.graphql.common.schema.typefunctions.DateTimeScalar;
+import org.hypertrace.core.graphql.common.schema.typefunctions.DurationScalar;
 import org.hypertrace.core.graphql.common.schema.typefunctions.UnknownScalar;
 import org.hypertrace.core.graphql.spi.schema.GraphQlSchemaFragment;
 
@@ -14,15 +15,18 @@ class CommonSchemaFragment implements GraphQlSchemaFragment {
   private final DateTimeScalar dateTimeScalar;
   private final UnknownScalar unknownScalar;
   private final AttributeScopeDynamicEnum attributeScopeDynamicEnum;
+  private final DurationScalar durationScalar;
 
   @Inject
   CommonSchemaFragment(
       DateTimeScalar dateTimeScalar,
       UnknownScalar unknownScalar,
-      AttributeScopeDynamicEnum attributeScopeDynamicEnum) {
+      AttributeScopeDynamicEnum attributeScopeDynamicEnum,
+      DurationScalar durationScalar) {
     this.dateTimeScalar = dateTimeScalar;
     this.unknownScalar = unknownScalar;
     this.attributeScopeDynamicEnum = attributeScopeDynamicEnum;
+    this.durationScalar = durationScalar;
   }
 
   @Override
@@ -33,6 +37,6 @@ class CommonSchemaFragment implements GraphQlSchemaFragment {
   @Nonnull
   @Override
   public List<TypeFunction> typeFunctions() {
-    return List.of(this.unknownScalar, this.dateTimeScalar, this.attributeScopeDynamicEnum);
+    return List.of(this.unknownScalar, this.dateTimeScalar, this.attributeScopeDynamicEnum, this.durationScalar);
   }
 }

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/DurationScalar.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/DurationScalar.java
@@ -1,0 +1,77 @@
+package org.hypertrace.core.graphql.common.schema.typefunctions;
+
+import graphql.GraphqlErrorException;
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.annotations.processor.typeFunctions.TypeFunction;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+import java.lang.reflect.AnnotatedType;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.util.function.Function;
+
+public class DurationScalar implements TypeFunction {
+
+  private static final GraphQLScalarType DURATION_SCALAR =
+      GraphQLScalarType.newScalar()
+          .name("Duration")
+          .description("An ISO-8601 formatted Duration Scalar")
+          .coercing(
+              new Coercing<Duration, String>() {
+                @Override
+                public String serialize(Object fetcherResult) throws CoercingSerializeException {
+                  return toDuration(fetcherResult, CoercingSerializeException::new).toString();
+                }
+
+                @Override
+                public Duration parseValue(Object input) throws CoercingParseValueException {
+                  return toDuration(input, CoercingParseValueException::new);
+                }
+
+                @Override
+                public Duration parseLiteral(Object input) throws CoercingParseLiteralException {
+                  return toDuration(input, CoercingParseLiteralException::new);
+                }
+
+                private <E extends GraphqlErrorException> Duration toDuration(
+                    Object durationInput, Function<Exception, E> errorWrapper) throws E {
+                  try {
+                    if (durationInput instanceof Duration) {
+                      return Duration.from((Duration) durationInput);
+                    }
+                    if (durationInput instanceof CharSequence) {
+                      return Duration.parse((CharSequence) durationInput);
+                    }
+                    if (durationInput instanceof StringValue) {
+                      return Duration.parse(((StringValue) durationInput).getValue());
+                    }
+                  } catch (Exception exception) {
+                    throw errorWrapper.apply(exception);
+                  }
+                  throw errorWrapper.apply(
+                      new DateTimeException(
+                          String.format(
+                              "Cannot convert provided format '%s' to Duration",
+                              durationInput.getClass().getCanonicalName())));
+                }
+              })
+          .build();
+
+  @Override
+  public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
+    return Duration.class.isAssignableFrom(aClass);
+  }
+
+  @Override
+  public GraphQLScalarType buildType(
+      boolean input,
+      Class<?> aClass,
+      AnnotatedType annotatedType,
+      ProcessingElementsContainer container) {
+    return DURATION_SCALAR;
+  }
+}

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/DurationScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/DurationScalarTest.java
@@ -1,0 +1,66 @@
+package org.hypertrace.core.graphql.common.schema.scalars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.language.StringValue;
+import graphql.schema.GraphQLScalarType;
+import java.lang.reflect.AnnotatedType;
+import java.time.Duration;
+import java.time.Instant;
+import org.hypertrace.core.graphql.common.schema.typefunctions.DurationScalar;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DurationScalarTest {
+
+  private static final String TEST_DURATION_STRING = "PT2H30M";
+  private static final Duration TEST_DURATION = Duration.parse(TEST_DURATION_STRING);
+  private DurationScalar durationScalar;
+  private GraphQLScalarType durationType;
+  @Mock AnnotatedType mockAnnotatedType;
+  // Can't actually mock class, but it's not used so to convey intent using the Mock class.
+  private final Class<?> mockAnnotatedClass = Mock.class;
+  @Mock ProcessingElementsContainer mockProcessingElementsContainer;
+
+  @BeforeEach
+  void beforeEach() {
+    this.durationScalar = new DurationScalar();
+    // Can't actually mock class, but it's not used so to convey intent using
+    this.durationType =
+        this.durationScalar.buildType(
+            false, mockAnnotatedClass, mockAnnotatedType, mockProcessingElementsContainer);
+  }
+
+  @Test
+  void canDetermineIfConvertible() {
+    assertTrue(this.durationScalar.canBuildType(Duration.class, this.mockAnnotatedType));
+    assertFalse(this.durationScalar.canBuildType(Instant.class, this.mockAnnotatedType));
+  }
+
+  @Test
+  void canConvertFromLiteral() {
+    assertEquals(TEST_DURATION, durationType.getCoercing().parseLiteral(TEST_DURATION_STRING));
+  }
+
+  @Test
+  void canSerialize() {
+    assertEquals(TEST_DURATION_STRING, durationType.getCoercing().serialize(TEST_DURATION));
+    assertEquals(TEST_DURATION_STRING, durationType.getCoercing().serialize(TEST_DURATION_STRING));
+  }
+
+  @Test
+  void canConvertFromValue() {
+    assertEquals(
+        TEST_DURATION,
+        durationType
+            .getCoercing()
+            .parseValue(StringValue.newStringValue().value(TEST_DURATION_STRING).build()));
+  }
+}


### PR DESCRIPTION
## Description
Adds support for a duration scalar using the ISO-8601 format for transport (matching what we already due for instant)

### Testing
Added unit tests, also added to a schema and spun up to verify the integration.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
