### PR TITLE
feat: add error logging operator to rx utils

### DIFF
--- a/hypertrace-core-graphql-rx-utils/src/main/java/org/hypertrace/core/graphql/rx/ObservableUtils.java
+++ b/hypertrace-core-graphql-rx-utils/src/main/java/org/hypertrace/core/graphql/rx/ObservableUtils.java
@@ -1,0 +1,33 @@
+package org.hypertrace.core.graphql.rx;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableSource;
+import io.reactivex.rxjava3.functions.Function;
+import org.slf4j.Logger;
+
+public class ObservableUtils {
+
+  // Not instantiable
+  private ObservableUtils() {}
+
+  /**
+   * Logs any encountered error with the provided logger at the error level. Effectively, this skips
+   * the causing element, but resumes the observable without affecting other elements.
+   *
+   * <p>This is intended to be used with the {@link Observable#onErrorResumeNext(Function)
+   * onErrorResumeNext} operator
+   *
+   * @param logger Logger to be used to log the message
+   * @param <T> unused type parameter as the provided function provides no values
+   * @return a function that can be provided to the {@link Observable#onErrorResumeNext(Function)
+   *     onErrorResumeNext} operator
+   */
+  public static <T>
+      Function<? super Throwable, ? extends ObservableSource<? extends T>> logErrorAndSkip(
+          Logger logger) {
+    return error -> {
+      logger.error("Encountered error, dropping value", error);
+      return Observable.empty();
+    };
+  }
+}


### PR DESCRIPTION
## Description

A common pattern we have (but don't always correctly implement) is handling a server response that contains unknown data - for example, an unexpected enum value. In these cases, we want to drop this response, log an error message, but not error out the entire request. As an example, imagine a new attribute data type is added to the system. Until graphql adds support for it, it won't be returned as it's not present in the graphql schema. At the same time, we don't want to stop returning attributes of known types when all attributes are requested, as that would break the whole system and make it so graphql is not forward compatible. So instead, we should log about the unknown type, drop the attribute from the list and proceed. That's where this operator comes in - it's used like:
```java
        someSourceObservableThatMayThrow
          .onErrorResumeNext(logErrorAndSkip(log)); // Uses logger local to this class
```

### Testing
Incoming unit test

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
