### PR TITLE
refactor: add a simple context request to simplify queries

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/CommonRequestModule.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/CommonRequestModule.java
@@ -14,6 +14,7 @@ public class CommonRequestModule extends AbstractModule {
     bind(ResultSetRequestBuilder.class).to(DefaultResultSetRequestBuilder.class);
     bind(AttributeRequestBuilder.class).to(DefaultAttributeRequestBuilder.class);
     bind(FilterRequestBuilder.class).to(DefaultFilterRequestBuilder.class);
+    bind(ContextualRequestBuilder.class).to(SimpleContextualRequestBuilder.class);
     requireBinding(AttributeStore.class);
     requireBinding(ArgumentDeserializer.class);
     requireBinding(AttributeAssociator.class);

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ContextualRequest.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ContextualRequest.java
@@ -1,0 +1,7 @@
+package org.hypertrace.core.graphql.common.request;
+
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+
+public interface ContextualRequest {
+  GraphQlRequestContext context();
+}

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ContextualRequestBuilder.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ContextualRequestBuilder.java
@@ -1,0 +1,7 @@
+package org.hypertrace.core.graphql.common.request;
+
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+
+public interface ContextualRequestBuilder {
+  ContextualRequest build(GraphQlRequestContext context);
+}

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequest.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequest.java
@@ -6,10 +6,8 @@ import java.util.Optional;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
-import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 
-public interface ResultSetRequest<O extends OrderArgument> {
-  GraphQlRequestContext context();
+public interface ResultSetRequest<O extends OrderArgument> extends ContextualRequest {
 
   // All attributes to fetch, including ID
   Collection<AttributeRequest> attributes();

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/SimpleContextualRequestBuilder.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/SimpleContextualRequestBuilder.java
@@ -1,0 +1,19 @@
+package org.hypertrace.core.graphql.common.request;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+
+class SimpleContextualRequestBuilder implements ContextualRequestBuilder {
+
+  @Override
+  public ContextualRequest build(GraphQlRequestContext context) {
+    return new SimpleContextualRequest(context);
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  private static class SimpleContextualRequest implements ContextualRequest {
+    GraphQlRequestContext context;
+  }
+}

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/request/LogEventRequest.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/request/LogEventRequest.java
@@ -4,14 +4,12 @@ import java.util.Collection;
 import java.util.List;
 import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
+import org.hypertrace.core.graphql.common.request.ContextualRequest;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
-import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 
-public interface LogEventRequest {
-  GraphQlRequestContext context();
-
+public interface LogEventRequest extends ContextualRequest {
   // All attributes to fetch
   Collection<AttributeRequest> attributes();
 

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/request/TraceRequest.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/request/TraceRequest.java
@@ -1,13 +1,11 @@
 package org.hypertrace.core.graphql.trace.request;
 
+import org.hypertrace.core.graphql.common.request.ContextualRequest;
 import org.hypertrace.core.graphql.common.request.ResultSetRequest;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
-import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.trace.schema.arguments.TraceType;
 
-public interface TraceRequest {
-  GraphQlRequestContext context();
-
+public interface TraceRequest extends ContextualRequest {
   ResultSetRequest<OrderArgument> resultSetRequest();
 
   TraceType traceType();


### PR DESCRIPTION
## Description
We often duplicate request objects per api on get requests without params - this common builder allows using a pre-existing request in those cases.