### PR TITLE
feat: add support for optional tyoe usage in schema

### DIFF
--- a/hypertrace-core-graphql-deserialization/build.gradle.kts
+++ b/hypertrace-core-graphql-deserialization/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   compileOnly("org.projectlombok:lombok")
 
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
   implementation("org.slf4j:slf4j-api")
 
   testImplementation("org.junit.jupiter:junit-jupiter")

--- a/hypertrace-core-graphql-deserialization/src/main/java/org/hypertrace/core/graphql/deserialization/DefaultArgumentDeserializer.java
+++ b/hypertrace-core-graphql-deserialization/src/main/java/org/hypertrace/core/graphql/deserialization/DefaultArgumentDeserializer.java
@@ -3,6 +3,7 @@ package org.hypertrace.core.graphql.deserialization;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Collection;
 import java.util.List;
@@ -20,7 +21,8 @@ import org.slf4j.LoggerFactory;
 
 class DefaultArgumentDeserializer implements ArgumentDeserializer {
 
-  private static final List<Module> defaultModules = List.of(new JavaTimeModule());
+  private static final List<Module> defaultModules =
+      List.of(new JavaTimeModule(), new Jdk8Module());
   private static final Logger LOG = LoggerFactory.getLogger(DefaultArgumentDeserializer.class);
 
   private final ObjectMapper objectMapper;

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -26,8 +26,9 @@ dependencies {
     api("io.grpc:grpc-core:1.36.0")
     api("io.grpc:grpc-stub:1.36.0")
     api("io.grpc:grpc-context:1.36.0")
-    api("com.fasterxml.jackson.core:jackson-databind:2.12.1")
-    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1")
+    api("com.fasterxml.jackson.core:jackson-databind:2.12.3")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.3")
     api("org.apache.commons:commons-text:1.9")
     api("io.opentelemetry:opentelemetry-proto:1.1.0-alpha")
 


### PR DESCRIPTION
## Description
Throughout the gql modules we avoid using null and instead use safer constructs like Optional and Maybe to handle presence. In the schema, nullability is handled through annotations, but within the code we would like to keep the objects consistent with the rest of the code. graphql-java-annotations already supports this, so here we bring our deserializer in line.

### Testing
Manually verified with an optional type