### PR TITLE
fix: apply limit on span log fetch

### DIFF
--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/SelectionExpressionSetConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/SelectionExpressionSetConverter.java
@@ -1,10 +1,10 @@
 package org.hypertrace.core.graphql.utils.gateway;
 
+import com.google.common.collect.ImmutableSet;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Collection;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.utils.Converter;
@@ -25,7 +25,8 @@ class SelectionExpressionSetConverter
   public Single<Set<Expression>> convert(Collection<AttributeRequest> attributeRequests) {
     return Observable.fromIterable(attributeRequests)
         .flatMapSingle(this::buildAliasedSelectionExpression)
-        .collect(Collectors.toUnmodifiableSet());
+        .collectInto(ImmutableSet.<Expression>builder(), ImmutableSet.Builder::add)
+        .map(ImmutableSet.Builder::build);
   }
 
   private Single<Expression> buildAliasedSelectionExpression(AttributeRequest attributeRequest) {

--- a/hypertrace-core-graphql-service/build.gradle.kts
+++ b/hypertrace-core-graphql-service/build.gradle.kts
@@ -12,9 +12,9 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
   implementation("org.slf4j:slf4j-api")
 
-  implementation("org.eclipse.jetty:jetty-server:9.4.39.v20210325")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.39.v20210325")
-  implementation("org.eclipse.jetty:jetty-servlets:9.4.39.v20210325")
+  implementation("org.eclipse.jetty:jetty-server:9.4.42.v20210604")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.42.v20210604")
+  implementation("org.eclipse.jetty:jetty-servlets:9.4.42.v20210604")
 
   implementation("com.graphql-java-kickstart:graphql-java-servlet")
   implementation(project(":hypertrace-core-graphql-impl"))

--- a/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/DaoTestUtil.java
+++ b/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/DaoTestUtil.java
@@ -81,7 +81,7 @@ class DaoTestUtil {
 
   @Value
   @Accessors(fluent = true)
-  static class DefaultResultSetRequest implements ResultSetRequest {
+  static class DefaultResultSetRequest implements ResultSetRequest<OrderArgument> {
 
     GraphQlRequestContext context;
     Collection<AttributeRequest> attributes;
@@ -89,7 +89,7 @@ class DaoTestUtil {
     AttributeRequest idAttribute;
     int limit;
     int offset;
-    List<AttributeAssociation> orderArguments;
+    List<AttributeAssociation<OrderArgument>> orderArguments;
     Collection<AttributeAssociation<FilterArgument>> filterArguments;
     Optional<String> spaceId;
   }


### PR DESCRIPTION
## Description
Fetching the logs to join into a span request previously did not provide a limit, meaning it limited to 10 logs total across all spans in the request. Instead, requesting up to 1000 now. Changed the tests to match objects rather than fields, which is more robust as it catches unintended fields too (adding a new field like limit should have failed the test, and didn't before this change). Also tweaked a few things in other places to support predictable iteration order.

### Testing
UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
