### PR TITLE
ENG-9484 expose user roles in GraphQlRequestContext

### DIFF
--- a/helm/templates/serviceconfig.yaml
+++ b/helm/templates/serviceconfig.yaml
@@ -26,3 +26,5 @@ data:
       host = {{ .Values.serviceConfig.gatewayService.host }}
       port = {{ .Values.serviceConfig.gatewayService.port }}
     }
+
+    jwt.roles.claim.name = {{ .Values.serviceConfig.jwtRolesClaimName }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,6 +51,7 @@ serviceConfig:
   gatewayService:
     host: gateway-service
     port: 50071
+  jwtRolesClaimName: "https://hypertrace.org/roles"
 logConfig:
   name: hypertrace-core-graphql-log-config
   rootLogger:

--- a/hypertrace-core-graphql-context/build.gradle.kts
+++ b/hypertrace-core-graphql-context/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
   implementation(project(":hypertrace-core-graphql-spi"))
   implementation("com.google.guava:guava")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils")
 
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.mockito:mockito-core")

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
@@ -6,7 +6,6 @@ import graphql.kickstart.servlet.context.DefaultGraphQLServletContext;
 import graphql.kickstart.servlet.context.DefaultGraphQLServletContextBuilder;
 import graphql.kickstart.servlet.context.GraphQLServletContext;
 import graphql.schema.DataFetcher;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -88,15 +87,19 @@ class DefaultGraphQlRequestContextBuilder extends DefaultGraphQLServletContextBu
 
     @Override
     public List<String> getRoles() {
-      return getAuthorizationHeader().map(authHeader -> {
-        String rolesClaimName = DefaultGraphQlRequestContextBuilder.this.serviceConfig.getRolesClaimName();
-        if (rolesClaimName == null || rolesClaimName.isEmpty()) {
-          return new ArrayList<String>();
-        }
-        RequestContext requestContext = new RequestContext();
-        requestContext.add(AUTHORIZATION_HEADER_KEY.toLowerCase(), authHeader);
-        return requestContext.getRoles(rolesClaimName);
-      }).orElse(Collections.emptyList());
+      return getAuthorizationHeader()
+          .map(
+              authHeader -> {
+                String rolesClaimName =
+                    DefaultGraphQlRequestContextBuilder.this.serviceConfig.getRolesClaimName();
+                if (rolesClaimName == null || rolesClaimName.isEmpty()) {
+                  return new ArrayList<String>();
+                }
+                RequestContext requestContext = new RequestContext();
+                requestContext.add(AUTHORIZATION_HEADER_KEY.toLowerCase(), authHeader);
+                return requestContext.getRoles(rolesClaimName);
+              })
+          .orElse(Collections.emptyList());
     }
 
     @Override

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
@@ -7,6 +7,7 @@ import graphql.kickstart.servlet.context.DefaultGraphQLServletContextBuilder;
 import graphql.kickstart.servlet.context.GraphQLServletContext;
 import graphql.schema.DataFetcher;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.dataloader.DataLoaderRegistry;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 
 class DefaultGraphQlRequestContextBuilder extends DefaultGraphQLServletContextBuilder
     implements GraphQlRequestContextBuilder {
@@ -84,7 +86,12 @@ class DefaultGraphQlRequestContextBuilder extends DefaultGraphQLServletContextBu
 
     @Override
     public List<String> getRoles() {
-      return null;
+      return getAuthorizationHeader().map(authHeader -> {
+        String rolesClaimName = DefaultGraphQlRequestContextBuilder.this.serviceConfig.getRolesClaimName();
+        RequestContext requestContext = new RequestContext();
+        requestContext.add(AUTHORIZATION_HEADER_KEY.toLowerCase(), authHeader);
+        return requestContext.getRoles(rolesClaimName);
+      }).orElse(Collections.emptyList());
     }
 
     @Override

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
@@ -6,6 +6,8 @@ import graphql.kickstart.servlet.context.DefaultGraphQLServletContext;
 import graphql.kickstart.servlet.context.DefaultGraphQLServletContextBuilder;
 import graphql.kickstart.servlet.context.GraphQLServletContext;
 import graphql.schema.DataFetcher;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -88,6 +90,9 @@ class DefaultGraphQlRequestContextBuilder extends DefaultGraphQLServletContextBu
     public List<String> getRoles() {
       return getAuthorizationHeader().map(authHeader -> {
         String rolesClaimName = DefaultGraphQlRequestContextBuilder.this.serviceConfig.getRolesClaimName();
+        if (rolesClaimName == null || rolesClaimName.isEmpty()) {
+          return new ArrayList<String>();
+        }
         RequestContext requestContext = new RequestContext();
         requestContext.add(AUTHORIZATION_HEADER_KEY.toLowerCase(), authHeader);
         return requestContext.getRoles(rolesClaimName);

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilder.java
@@ -7,6 +7,7 @@ import graphql.kickstart.servlet.context.DefaultGraphQLServletContextBuilder;
 import graphql.kickstart.servlet.context.GraphQLServletContext;
 import graphql.schema.DataFetcher;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -79,6 +80,11 @@ class DefaultGraphQlRequestContextBuilder extends DefaultGraphQLServletContextBu
       HttpServletRequest request = this.servletContext.getHttpServletRequest();
       return Optional.ofNullable(request.getHeader(TENANT_ID_HEADER_KEY))
           .or(DefaultGraphQlRequestContextBuilder.this.serviceConfig::getDefaultTenantId);
+    }
+
+    @Override
+    public List<String> getRoles() {
+      return null;
     }
 
     @Override

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
@@ -2,7 +2,6 @@ package org.hypertrace.core.graphql.context;
 
 import graphql.kickstart.execution.context.GraphQLContext;
 import graphql.schema.DataFetcher;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
@@ -2,6 +2,8 @@ package org.hypertrace.core.graphql.context;
 
 import graphql.kickstart.execution.context.GraphQLContext;
 import graphql.schema.DataFetcher;
+
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -17,6 +19,8 @@ public interface GraphQlRequestContext extends GraphQLContext {
   Optional<String> getAuthorizationHeader();
 
   Optional<String> getTenantId();
+
+  List<String> getRoles();
 
   Map<String, String> getTracingContextHeaders();
 

--- a/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
+++ b/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
@@ -10,10 +10,12 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import graphql.schema.DataFetcher;
 import java.util.Collections;
@@ -134,5 +136,23 @@ class DefaultGraphQlRequestContextBuilderTest {
             "x-b3-parent-trace-id",
             "x-b3-parent-trace-id value"),
         this.requestContext.getTracingContextHeaders());
+  }
+
+  @Test
+  void returnsRolesIfPresentInJwt() {
+    String rolesClaim = "https://example.com/roles";
+    List<String> expectedRoles = ImmutableList.of("user", "admin");
+    List<String> actualRoles = this.requestContext.getRoles();
+    doReturn(rolesClaim).when(this.mockServiceConfig).getRolesClaimName();
+    doReturn("Bearer " + getJwtWithRoles()).when(this.mockRequest).getHeader("Authorization");
+    assertEquals(expectedRoles, actualRoles);
+  }
+
+  private String getJwtWithRoles() {
+    return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6" +
+        "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u" +
+        "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1" +
+        "cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL2V4YW1wbGUuY29tL3JvbGVzIjpbInVzZXIiLCJhZG1pbiJdfQ.PKWns1aii5HEOje-8" +
+        "vGwvlYcWYMi4LWgw9CUQlc0npM";
   }
 }

--- a/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
+++ b/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
@@ -140,11 +140,11 @@ class DefaultGraphQlRequestContextBuilderTest {
 
   @Test
   void returnsRolesIfPresentInJwt() {
-    String rolesClaim = "https://example.com/roles";
+    String rolesClaimName = "https://example.com/roles";
     List<String> expectedRoles = ImmutableList.of("user", "admin");
-    List<String> actualRoles = this.requestContext.getRoles();
-    doReturn(rolesClaim).when(this.mockServiceConfig).getRolesClaimName();
+    doReturn(rolesClaimName).when(this.mockServiceConfig).getRolesClaimName();
     doReturn("Bearer " + getJwtWithRoles()).when(this.mockRequest).getHeader("Authorization");
+    List<String> actualRoles = this.requestContext.getRoles();
     assertEquals(expectedRoles, actualRoles);
   }
 

--- a/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
+++ b/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
@@ -148,11 +148,60 @@ class DefaultGraphQlRequestContextBuilderTest {
     assertEquals(expectedRoles, actualRoles);
   }
 
+  @Test
+  void returnsEmptyRolesIfRolesClaimNameIsInvalid() {
+    String rolesClaimName = "invalidRolesClaim";
+    doReturn(rolesClaimName).when(this.mockServiceConfig).getRolesClaimName();
+    doReturn("Bearer " + getJwtWithRoles()).when(this.mockRequest).getHeader("Authorization");
+    List<String> actualRoles = this.requestContext.getRoles();
+    assertEquals(Collections.emptyList(), actualRoles);
+  }
+
+  @Test
+  void returnsEmptyRolesIfRolesClaimNameIsNull() {
+    doReturn(null).when(this.mockServiceConfig).getRolesClaimName();
+    doReturn("Bearer " + getJwtWithRoles()).when(this.mockRequest).getHeader("Authorization");
+    List<String> actualRoles = this.requestContext.getRoles();
+    assertEquals(Collections.emptyList(), actualRoles);
+  }
+
+  @Test
+  void returnsEmptyRolesIfClaimNotPresentInJwt() {
+    String rolesClaimName = "https://example.com/roles";
+    doReturn(rolesClaimName).when(this.mockServiceConfig).getRolesClaimName();
+    doReturn("Bearer " + getJwtWithOutRoles()).when(this.mockRequest).getHeader("Authorization");
+    List<String> actualRoles = this.requestContext.getRoles();
+    assertEquals(Collections.emptyList(), actualRoles);
+  }
+
+  @Test
+  void returnsEmptyRolesIfAuthHeaderNotPresent() {
+    doReturn(null).when(this.mockRequest).getHeader("Authorization");
+    List<String> actualRoles = this.requestContext.getRoles();
+    assertEquals(Collections.emptyList(), actualRoles);
+  }
+
+  @Test
+  void returnsEmptyRolesIfJwtIsInvalid() {
+    String rolesClaimName = "https://example.com/roles";
+    doReturn(rolesClaimName).when(this.mockServiceConfig).getRolesClaimName();
+    doReturn("Bearer ABC").when(this.mockRequest).getHeader("Authorization");
+    List<String> actualRoles = this.requestContext.getRoles();
+    assertEquals(Collections.emptyList(), actualRoles);
+  }
+
   private String getJwtWithRoles() {
     return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6" +
         "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u" +
         "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1" +
         "cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL2V4YW1wbGUuY29tL3JvbGVzIjpbInVzZXIiLCJhZG1pbiJdfQ.PKWns1aii5HEOje-8" +
         "vGwvlYcWYMi4LWgw9CUQlc0npM";
+  }
+
+  private String getJwtWithOutRoles() {
+    return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6" +
+        "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u" +
+        "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1" +
+        "cmUiOiJ3d3cuZXhhbXBsZS5jb20ifQ.Ui1Z2RhiVe3tq6uJPgcyjsfDBdeOeINs_gXEHC6cdpU";
   }
 }

--- a/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
+++ b/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
@@ -191,17 +191,17 @@ class DefaultGraphQlRequestContextBuilderTest {
   }
 
   private String getJwtWithRoles() {
-    return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6" +
-        "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u" +
-        "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1" +
-        "cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL2V4YW1wbGUuY29tL3JvbGVzIjpbInVzZXIiLCJhZG1pbiJdfQ.PKWns1aii5HEOje-8" +
-        "vGwvlYcWYMi4LWgw9CUQlc0npM";
+    return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6"
+        + "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u"
+        + "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1"
+        + "cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL2V4YW1wbGUuY29tL3JvbGVzIjpbInVzZXIiLCJhZG1pbiJdfQ.PKWns1aii5HEOje-8"
+        + "vGwvlYcWYMi4LWgw9CUQlc0npM";
   }
 
   private String getJwtWithOutRoles() {
-    return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6" +
-        "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u" +
-        "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1" +
-        "cmUiOiJ3d3cuZXhhbXBsZS5jb20ifQ.Ui1Z2RhiVe3tq6uJPgcyjsfDBdeOeINs_gXEHC6cdpU";
+    return "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6"
+        + "MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5u"
+        + "eSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1"
+        + "cmUiOiJ3d3cuZXhhbXBsZS5jb20ifQ.Ui1Z2RhiVe3tq6uJPgcyjsfDBdeOeINs_gXEHC6cdpU";
   }
 }

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   constraints {
 
-    api("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.4")
+    api("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.1")
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.4")
     api("org.hypertrace.gateway.service:gateway-service-api:0.1.59")
     api("org.hypertrace.core.attribute.service:attribute-service-api:0.9.3")

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -98,6 +98,11 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
     return this.gatewayServicePort;
   }
 
+  @Override
+  public String getRolesClaimName() {
+    return null;
+  }
+
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {
     try {
       return Optional.ofNullable(valueSupplier.get());

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -23,6 +23,8 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
 
+  private static final String JWT_ROLES_CLAIM_NAME = "jwt.roles.claim.name";
+
   private final String serviceName;
   private final int servicePort;
   private final String graphqlUrlPath;
@@ -33,6 +35,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private final int attributeServicePort;
   private final String gatewayServiceHost;
   private final int gatewayServicePort;
+  private final String rolesClaimName;
 
   DefaultGraphQlServiceConfig(Config untypedConfig) {
     this.serviceName = untypedConfig.getString(SERVICE_NAME_CONFIG);
@@ -46,6 +49,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
     this.attributeServicePort = untypedConfig.getInt(ATTRIBUTE_SERVICE_PORT_PROPERTY);
     this.gatewayServiceHost = untypedConfig.getString(GATEWAY_SERVICE_HOST_PROPERTY);
     this.gatewayServicePort = untypedConfig.getInt(GATEWAY_SERVICE_PORT_PROPERTY);
+    this.rolesClaimName = untypedConfig.getString(JWT_ROLES_CLAIM_NAME);
   }
 
   @Override
@@ -100,7 +104,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
 
   @Override
   public String getRolesClaimName() {
-    return null;
+    return rolesClaimName;
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-core-graphql-service/src/main/resources/configs/common/application.conf
+++ b/hypertrace-core-graphql-service/src/main/resources/configs/common/application.conf
@@ -17,3 +17,5 @@ gateway.service = {
   host = localhost
   port = 50071
 }
+
+jwt.roles.claim.name = https://hypertrace.org/roles

--- a/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
@@ -23,4 +23,6 @@ public interface GraphQlServiceConfig {
   String getGatewayServiceHost();
 
   int getGatewayServicePort();
+
+  String getRolesClaimName();
 }


### PR DESCRIPTION
## Description
Exposing roles in graphql request context for future authorization support

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
