### PR TITLE
Gateway-Service Client Timeout Config

### DIFF
--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventDao.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventDao.java
@@ -40,8 +40,8 @@ class GatewayServiceLogEventDao implements LogEventDao {
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-            channelRegistry.forAddress(
-                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+                channelRegistry.forAddress(
+                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -61,8 +61,8 @@ class GatewayServiceLogEventDao implements LogEventDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .getLogEvents(request)));
   }
 }

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventDao.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventDao.java
@@ -19,11 +19,11 @@ import org.hypertrace.gateway.service.v1.log.events.LogEventsResponse;
 
 @Singleton
 class GatewayServiceLogEventDao implements LogEventDao {
-  private static final int DEFAULT_DEADLINE_SEC = 10;
   private final GatewayServiceFutureStub gatewayServiceStub;
   private final GrpcContextBuilder grpcContextBuilder;
   private final GatewayServiceLogEventsRequestBuilder requestBuilder;
   private final GatewayServiceLogEventsResponseConverter logEventConverter;
+  private final GraphQlServiceConfig serviceConfig;
 
   @Inject
   GatewayServiceLogEventDao(
@@ -36,11 +36,12 @@ class GatewayServiceLogEventDao implements LogEventDao {
     this.grpcContextBuilder = grpcContextBuilder;
     this.requestBuilder = requestBuilder;
     this.logEventConverter = logEventConverter;
+    this.serviceConfig = serviceConfig;
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-                channelRegistry.forAddress(
-                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+            channelRegistry.forAddress(
+                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -60,7 +61,8 @@ class GatewayServiceLogEventDao implements LogEventDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
+                            SECONDS)
                         .getLogEvents(request)));
   }
 }

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventDao.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventDao.java
@@ -1,6 +1,6 @@
 package org.hypertrace.core.graphql.log.event.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.grpc.CallCredentials;
 import io.reactivex.rxjava3.core.Single;
@@ -62,7 +62,7 @@ class GatewayServiceLogEventDao implements LogEventDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .getLogEvents(request)));
   }
 }

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.graphql.service;
 
 import com.typesafe.config.Config;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
@@ -22,7 +23,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
 
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
-  private static final String GATEWAY_SERVICE_RPC_CLIENT_DEADLINE = "gateway.service.deadline";
+  private static final String GATEWAY_SERVICE_CLIENT_TIMEOUT = "gateway.service.timeout";
 
   private final String serviceName;
   private final int servicePort;
@@ -34,7 +35,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private final int attributeServicePort;
   private final String gatewayServiceHost;
   private final int gatewayServicePort;
-  private final int gatewayServiceClientDeadline;
+  private final Duration gatewayServiceTimeout;
 
   DefaultGraphQlServiceConfig(Config untypedConfig) {
     this.serviceName = untypedConfig.getString(SERVICE_NAME_CONFIG);
@@ -48,7 +49,11 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
     this.attributeServicePort = untypedConfig.getInt(ATTRIBUTE_SERVICE_PORT_PROPERTY);
     this.gatewayServiceHost = untypedConfig.getString(GATEWAY_SERVICE_HOST_PROPERTY);
     this.gatewayServicePort = untypedConfig.getInt(GATEWAY_SERVICE_PORT_PROPERTY);
-    gatewayServiceClientDeadline = untypedConfig.getInt(GATEWAY_SERVICE_RPC_CLIENT_DEADLINE);
+    // fallback timeout: 10s
+    this.gatewayServiceTimeout =
+        untypedConfig.hasPath(GATEWAY_SERVICE_CLIENT_TIMEOUT)
+            ? untypedConfig.getDuration(GATEWAY_SERVICE_CLIENT_TIMEOUT)
+            : Duration.ofSeconds(10);
   }
 
   @Override
@@ -102,8 +107,8 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   }
 
   @Override
-  public int getGatewayServiceRPCClientDeadline() {
-    return gatewayServiceClientDeadline;
+  public Duration getGatewayServiceTimeout() {
+    return gatewayServiceTimeout;
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -22,6 +22,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
 
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
+  private static final String GATEWAY_SERVICE_RPC_CLIENT_DEADLINE = "gateway.service.deadline";
 
   private final String serviceName;
   private final int servicePort;
@@ -33,6 +34,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private final int attributeServicePort;
   private final String gatewayServiceHost;
   private final int gatewayServicePort;
+  private final int gatewayServiceClientDeadline;
 
   DefaultGraphQlServiceConfig(Config untypedConfig) {
     this.serviceName = untypedConfig.getString(SERVICE_NAME_CONFIG);
@@ -46,6 +48,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
     this.attributeServicePort = untypedConfig.getInt(ATTRIBUTE_SERVICE_PORT_PROPERTY);
     this.gatewayServiceHost = untypedConfig.getString(GATEWAY_SERVICE_HOST_PROPERTY);
     this.gatewayServicePort = untypedConfig.getInt(GATEWAY_SERVICE_PORT_PROPERTY);
+    gatewayServiceClientDeadline = untypedConfig.getInt(GATEWAY_SERVICE_RPC_CLIENT_DEADLINE);
   }
 
   @Override
@@ -96,6 +99,11 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   @Override
   public int getGatewayServicePort() {
     return this.gatewayServicePort;
+  }
+
+  @Override
+  public int getGatewayServiceRPCClientDeadline() {
+    return gatewayServiceClientDeadline;
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanDao.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanDao.java
@@ -58,8 +58,8 @@ class GatewayServiceSpanDao implements SpanDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .getSpans(request)));
   }
 }

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanDao.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanDao.java
@@ -8,6 +8,7 @@ import javax.inject.Singleton;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.span.request.SpanRequest;
 import org.hypertrace.core.graphql.span.schema.SpanResultSet;
+import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
 import org.hypertrace.core.graphql.utils.grpc.GrpcContextBuilder;
 import org.hypertrace.gateway.service.GatewayServiceGrpc.GatewayServiceFutureStub;
 import org.hypertrace.gateway.service.v1.span.SpansRequest;
@@ -15,15 +16,17 @@ import org.hypertrace.gateway.service.v1.span.SpansResponse;
 
 @Singleton
 class GatewayServiceSpanDao implements SpanDao {
-  private static final int DEFAULT_DEADLINE_SEC = 10;
+
   private final GatewayServiceFutureStub gatewayServiceStub;
   private final GrpcContextBuilder grpcContextBuilder;
   private final GatewayServiceSpanRequestBuilder requestBuilder;
   private final GatewayServiceSpanConverter spanConverter;
   private final SpanLogEventDao spanLogEventDao;
+  private final GraphQlServiceConfig serviceConfig;
 
   @Inject
   GatewayServiceSpanDao(
+      GraphQlServiceConfig serviceConfig,
       GatewayServiceFutureStub gatewayServiceFutureStub,
       GrpcContextBuilder grpcContextBuilder,
       GatewayServiceSpanRequestBuilder requestBuilder,
@@ -34,6 +37,7 @@ class GatewayServiceSpanDao implements SpanDao {
     this.spanConverter = spanConverter;
     this.spanLogEventDao = spanLogEventDao;
     this.gatewayServiceStub = gatewayServiceFutureStub;
+    this.serviceConfig = serviceConfig;
   }
 
   @Override
@@ -54,7 +58,8 @@ class GatewayServiceSpanDao implements SpanDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
+                            SECONDS)
                         .getSpans(request)));
   }
 }

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanDao.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanDao.java
@@ -1,6 +1,6 @@
 package org.hypertrace.core.graphql.span.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.reactivex.rxjava3.core.Single;
 import javax.inject.Inject;
@@ -59,7 +59,7 @@ class GatewayServiceSpanDao implements SpanDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .getSpans(request)));
   }
 }

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanDaoModule.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanDaoModule.java
@@ -32,6 +32,7 @@ public class SpanDaoModule extends AbstractModule {
   protected void configure() {
     bind(SpanDao.class).to(GatewayServiceSpanDao.class);
     requireBinding(GatewayServiceFutureStub.class);
+    requireBinding(GraphQlServiceConfig.class);
     requireBinding(CallCredentials.class);
     requireBinding(GraphQlServiceConfig.class);
     requireBinding(GrpcContextBuilder.class);

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanLogEventDao.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanLogEventDao.java
@@ -1,6 +1,6 @@
 package org.hypertrace.core.graphql.span.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.reactivex.rxjava3.core.Single;
 import java.util.Map;
@@ -76,7 +76,7 @@ class SpanLogEventDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .getLogEvents(request)));
   }
 }

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanLogEventDao.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanLogEventDao.java
@@ -37,6 +37,8 @@ class SpanLogEventDao {
   }
 
   /**
+   *
+   *
    * <ul>
    *   <li>1. Fetch log event attributes from {@code gqlRequest}
    *   <li>2. Build log event request using attribute and spanIds as filter
@@ -73,8 +75,8 @@ class SpanLogEventDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .getLogEvents(request)));
   }
 }

--- a/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.graphql.spi.config;
 
+import java.time.Duration;
 import java.util.Optional;
 
 public interface GraphQlServiceConfig {
@@ -24,5 +25,5 @@ public interface GraphQlServiceConfig {
 
   int getGatewayServicePort();
 
-  int getGatewayServiceRPCClientDeadline();
+  Duration getGatewayServiceTimeout();
 }

--- a/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
@@ -23,4 +23,6 @@ public interface GraphQlServiceConfig {
   String getGatewayServiceHost();
 
   int getGatewayServicePort();
+
+  int getGatewayServiceRPCClientDeadline();
 }

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
@@ -41,8 +41,8 @@ class GatewayServiceTraceDao implements TraceDao {
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-            channelRegistry.forAddress(
-                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+                channelRegistry.forAddress(
+                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -63,8 +63,8 @@ class GatewayServiceTraceDao implements TraceDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .getTraces(request)));
   }
 }

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
@@ -19,11 +19,12 @@ import org.hypertrace.gateway.service.v1.trace.TracesResponse;
 
 @Singleton
 class GatewayServiceTraceDao implements TraceDao {
-  private static final int DEFAULT_DEADLINE_SEC = 10;
+
   private final GatewayServiceFutureStub gatewayServiceStub;
   private final GrpcContextBuilder grpcContextBuilder;
   private final GatewayServiceTraceRequestBuilder requestBuilder;
   private final GatewayServiceTraceConverter traceConverter;
+  private final GraphQlServiceConfig serviceConfig;
 
   @Inject
   GatewayServiceTraceDao(
@@ -36,11 +37,12 @@ class GatewayServiceTraceDao implements TraceDao {
     this.grpcContextBuilder = grpcContextBuilder;
     this.requestBuilder = requestBuilder;
     this.traceConverter = traceConverter;
+    this.serviceConfig = serviceConfig;
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-                channelRegistry.forAddress(
-                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+            channelRegistry.forAddress(
+                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -61,7 +63,8 @@ class GatewayServiceTraceDao implements TraceDao {
             .call(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
+                            SECONDS)
                         .getTraces(request)));
   }
 }

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceDao.java
@@ -1,6 +1,6 @@
 package org.hypertrace.core.graphql.trace.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.grpc.CallCredentials;
 import io.reactivex.rxjava3.core.Single;
@@ -64,7 +64,7 @@ class GatewayServiceTraceDao implements TraceDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .getTraces(request)));
   }
 }


### PR DESCRIPTION
## Description
These changes are in context of: hypertrace/hypertrace-core-graphql#69. Currently, we hardcode the deadline as 10s. Now, GATEWAY_SERVICE_DEADLINE is read from application.conf

### Testing
Deployed and tested the application manually. I am still seeing if I can write a UT for check if config value is being loaded properly.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

These changes are dependent on: https://github.com/hypertrace/hypertrace-service/pull/99
