### PR TITLE
Attribute Service Client Configurable Timeout

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-06-30T00:00:00.000Z
+        expires: 2021-09-01T00:00:00.000Z
 patch: {}
 

--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeClient.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/AttributeClient.java
@@ -37,9 +37,9 @@ class AttributeClient {
 
     this.attributeServiceClient =
         newStub(
-            grpcChannelRegistry.forAddress(
-                serviceConfig.getAttributeServiceHost(),
-                serviceConfig.getAttributeServicePort()))
+                grpcChannelRegistry.forAddress(
+                    serviceConfig.getAttributeServiceHost(),
+                    serviceConfig.getAttributeServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -48,7 +48,8 @@ class AttributeClient {
         .<AttributeMetadata>stream(
             streamObserver ->
                 this.attributeServiceClient
-                    .withDeadlineAfter(serviceConfig.getAttributeServiceTimeout().toMillis(),
+                    .withDeadlineAfter(
+                        serviceConfig.getAttributeServiceTimeout().toMillis(),
                         TimeUnit.MILLISECONDS)
                     .findAll(Empty.getDefaultInstance(), streamObserver))
         .mapOptional(this.translator::translate);

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -121,11 +121,8 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   }
 
   private Duration getTimeoutOrFallback(Supplier<Duration> durationSupplier) {
-    try {
-      return durationSupplier.get();
-    } catch (Throwable unused) {
-      return Duration.ofSeconds(DEFAULT_CLIENT_TIMEOUT_SECONDS);
-    }
+    return optionallyGet(durationSupplier)
+        .orElse(Duration.ofSeconds(DEFAULT_CLIENT_TIMEOUT_SECONDS));
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -20,6 +20,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
 
   private static final String ATTRIBUTE_SERVICE_HOST_PROPERTY = "attribute.service.host";
   private static final String ATTRIBUTE_SERVICE_PORT_PROPERTY = "attribute.service.port";
+  private static final String ATTRIBUTE_SERVICE_CLIENT_TIMEOUT = "attribute.service.timeout";
 
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
@@ -33,6 +34,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private final int maxIoThreads;
   private final String attributeServiceHost;
   private final int attributeServicePort;
+  private final Duration attributeServiceTimeout;
   private final String gatewayServiceHost;
   private final int gatewayServicePort;
   private final Duration gatewayServiceTimeout;
@@ -47,6 +49,11 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
 
     this.attributeServiceHost = untypedConfig.getString(ATTRIBUTE_SERVICE_HOST_PROPERTY);
     this.attributeServicePort = untypedConfig.getInt(ATTRIBUTE_SERVICE_PORT_PROPERTY);
+    // fallback timeout: 10s
+    this.attributeServiceTimeout =
+        untypedConfig.hasPath(ATTRIBUTE_SERVICE_CLIENT_TIMEOUT)
+            ? untypedConfig.getDuration(ATTRIBUTE_SERVICE_CLIENT_TIMEOUT)
+            : Duration.ofSeconds(10);
     this.gatewayServiceHost = untypedConfig.getString(GATEWAY_SERVICE_HOST_PROPERTY);
     this.gatewayServicePort = untypedConfig.getInt(GATEWAY_SERVICE_PORT_PROPERTY);
     // fallback timeout: 10s
@@ -94,6 +101,11 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   @Override
   public int getAttributeServicePort() {
     return this.attributeServicePort;
+  }
+
+  @Override
+  public Duration getAttributeServiceTimeout() {
+    return attributeServiceTimeout;
   }
 
   @Override

--- a/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
@@ -21,6 +21,8 @@ public interface GraphQlServiceConfig {
 
   int getAttributeServicePort();
 
+  Duration getAttributeServiceTimeout();
+
   String getGatewayServiceHost();
 
   int getGatewayServicePort();


### PR DESCRIPTION
## Description
Like the PR [here](https://github.com/hypertrace/hypertrace-graphql/pull/91/files), this change is to make client timeout for the Attribute Service configurable.

### Testing
Deployed and tested the application locally. Scenarios:

1. Missing config: Default timeout is used.
2. Timeout configured: Configured value is used.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules