### PR TITLE
Revert "Filter out internal attributes using the internal flag"

### DIFF
--- a/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/CachingAttributeStore.java
+++ b/hypertrace-core-graphql-attribute-store/src/main/java/org/hypertrace/core/graphql/attributes/CachingAttributeStore.java
@@ -7,7 +7,6 @@ import java.util.NoSuchElementException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
-import org.hypertrace.core.attribute.service.v1.AttributeMetadataFilter;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
 import org.hypertrace.core.graphql.utils.grpc.GrpcChannelRegistry;
@@ -37,7 +36,6 @@ class CachingAttributeStore implements AttributeStore {
                 channelRegistry.forAddress(
                     serviceConfig.getAttributeServiceHost(),
                     serviceConfig.getAttributeServicePort()))
-            .withAttributeFilter(AttributeMetadataFilter.newBuilder().setInternal(false).build())
             .withCacheExpiration(Duration.ofMinutes(5))
             .withMaximumCacheContexts(1000)
             .build());

--- a/hypertrace-core-graphql-attribute-store/src/test/java/org/hypertrace/core/graphql/attributes/CachingAttributeStoreTest.java
+++ b/hypertrace-core-graphql-attribute-store/src/test/java/org/hypertrace/core/graphql/attributes/CachingAttributeStoreTest.java
@@ -53,11 +53,7 @@ class CachingAttributeStoreTest {
     AttributeModel spanIdAttribute =
         DefaultAttributeModel.builder().scope("SPAN").key("id").build();
     AttributeMetadata spanIdResponse =
-        AttributeMetadata.newBuilder()
-            .setScopeString("SPAN")
-            .setKey("id")
-            .setInternal(false)
-            .build();
+        AttributeMetadata.newBuilder().setScopeString("SPAN").setKey("id").build();
 
     when(this.mockAttributeClient.get("SPAN", "id")).thenReturn(Single.just(spanIdResponse));
     when(this.mockAttributeModeTranslator.translate(spanIdResponse))

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.1")
     api("org.hypertrace.gateway.service:gateway-service-api:0.1.59")
-    api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.13.5")
+    api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.13.3")
 
     api("com.google.inject:guice:4.2.3")
     api("com.graphql-java:graphql-java:15.0")
@@ -35,10 +35,10 @@ dependencies {
 
     runtime("org.apache.logging.log4j:log4j-slf4j-impl:2.14.0")
     runtime("io.grpc:grpc-netty:1.40.0")
-    runtime("io.netty:netty-codec-http2:4.1.68.Final") {
+    runtime("io.netty:netty-codec-http2:4.1.61.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
     }
-    runtime("io.netty:netty-handler-proxy:4.1.68.Final") {
+    runtime("io.netty:netty-handler-proxy:4.1.61.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
     }
   }


### PR DESCRIPTION
Reverts hypertrace/hypertrace-core-graphql#78

Attribute Service metadata filter https://github.com/hypertrace/attribute-service/pull/106 does not take care of the backward compatibility for attributes not having `internal` flag, leading to missing attributes while applying the `internal: false` filter in GraphQl