### PR TITLE
Add offsetTime Scalar to Typefunction

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/CommonSchemaFragment.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/CommonSchemaFragment.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import org.hypertrace.core.graphql.common.schema.typefunctions.AttributeScopeDynamicEnum;
 import org.hypertrace.core.graphql.common.schema.typefunctions.DateTimeScalar;
 import org.hypertrace.core.graphql.common.schema.typefunctions.DurationScalar;
+import org.hypertrace.core.graphql.common.schema.typefunctions.OffsetTimeScalar;
 import org.hypertrace.core.graphql.common.schema.typefunctions.UnknownScalar;
 import org.hypertrace.core.graphql.spi.schema.GraphQlSchemaFragment;
 
@@ -16,17 +17,20 @@ class CommonSchemaFragment implements GraphQlSchemaFragment {
   private final UnknownScalar unknownScalar;
   private final AttributeScopeDynamicEnum attributeScopeDynamicEnum;
   private final DurationScalar durationScalar;
+  private final OffsetTimeScalar offsetTimeScalar;
 
   @Inject
   CommonSchemaFragment(
       DateTimeScalar dateTimeScalar,
       UnknownScalar unknownScalar,
       AttributeScopeDynamicEnum attributeScopeDynamicEnum,
-      DurationScalar durationScalar) {
+      DurationScalar durationScalar,
+      OffsetTimeScalar offsetTimeScalar) {
     this.dateTimeScalar = dateTimeScalar;
     this.unknownScalar = unknownScalar;
     this.attributeScopeDynamicEnum = attributeScopeDynamicEnum;
     this.durationScalar = durationScalar;
+    this.offsetTimeScalar = offsetTimeScalar;
   }
 
   @Override
@@ -41,6 +45,7 @@ class CommonSchemaFragment implements GraphQlSchemaFragment {
         this.unknownScalar,
         this.dateTimeScalar,
         this.attributeScopeDynamicEnum,
-        this.durationScalar);
+        this.durationScalar,
+        this.offsetTimeScalar);
   }
 }

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/OffsetTimeScalar.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/OffsetTimeScalar.java
@@ -39,16 +39,16 @@ public class OffsetTimeScalar implements TypeFunction {
                 }
 
                 private <E extends GraphqlErrorException> OffsetTime toOffsetTime(
-                    Object instantInput, Function<Exception, E> errorWrapper) throws E {
+                    Object offsetInput, Function<Exception, E> errorWrapper) throws E {
                   try {
-                    if (instantInput instanceof TemporalAccessor) {
-                      return OffsetTime.from((TemporalAccessor) instantInput);
+                    if (offsetInput instanceof TemporalAccessor) {
+                      return OffsetTime.from((TemporalAccessor) offsetInput);
                     }
-                    if (instantInput instanceof CharSequence) {
-                      return OffsetTime.parse((CharSequence) instantInput);
+                    if (offsetInput instanceof CharSequence) {
+                      return OffsetTime.parse((CharSequence) offsetInput);
                     }
-                    if (instantInput instanceof StringValue) {
-                      return OffsetTime.parse(((StringValue) instantInput).getValue());
+                    if (offsetInput instanceof StringValue) {
+                      return OffsetTime.parse(((StringValue) offsetInput).getValue());
                     }
                   } catch (DateTimeException exception) {
                     throw errorWrapper.apply(exception);
@@ -57,7 +57,7 @@ public class OffsetTimeScalar implements TypeFunction {
                       new DateTimeException(
                           String.format(
                               "Cannot convert provided format '%s' to OffsetTime",
-                              instantInput.getClass().getCanonicalName())));
+                              offsetInput.getClass().getCanonicalName())));
                 }
               })
           .build();

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/OffsetTimeScalar.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/OffsetTimeScalar.java
@@ -11,44 +11,44 @@ import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 import java.lang.reflect.AnnotatedType;
 import java.time.DateTimeException;
-import java.time.Instant;
+import java.time.OffsetTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.function.Function;
 
-public class DateTimeScalar implements TypeFunction {
+public class OffsetTimeScalar implements TypeFunction {
 
-  private static final GraphQLScalarType DATE_TIME_SCALAR =
+  private static final GraphQLScalarType OFFSET_TIME_SCALAR =
       GraphQLScalarType.newScalar()
-          .name("DateTime")
-          .description("An ISO-8601 formatted DateTime Scalar")
+          .name("OffsetTime")
+          .description("An ISO-8601 formatted OffsetTime Scalar")
           .coercing(
-              new Coercing<Instant, String>() {
+              new Coercing<OffsetTime, String>() {
                 @Override
                 public String serialize(Object fetcherResult) throws CoercingSerializeException {
-                  return toInstant(fetcherResult, CoercingSerializeException::new).toString();
+                  return toOffsetTime(fetcherResult, CoercingSerializeException::new).toString();
                 }
 
                 @Override
-                public Instant parseValue(Object input) throws CoercingParseValueException {
-                  return toInstant(input, CoercingParseValueException::new);
+                public OffsetTime parseValue(Object input) throws CoercingParseValueException {
+                  return toOffsetTime(input, CoercingParseValueException::new);
                 }
 
                 @Override
-                public Instant parseLiteral(Object input) throws CoercingParseLiteralException {
-                  return toInstant(input, CoercingParseLiteralException::new);
+                public OffsetTime parseLiteral(Object input) throws CoercingParseLiteralException {
+                  return toOffsetTime(input, CoercingParseLiteralException::new);
                 }
 
-                private <E extends GraphqlErrorException> Instant toInstant(
+                private <E extends GraphqlErrorException> OffsetTime toOffsetTime(
                     Object instantInput, Function<Exception, E> errorWrapper) throws E {
                   try {
                     if (instantInput instanceof TemporalAccessor) {
-                      return Instant.from((TemporalAccessor) instantInput);
+                      return OffsetTime.from((TemporalAccessor) instantInput);
                     }
                     if (instantInput instanceof CharSequence) {
-                      return Instant.parse((CharSequence) instantInput);
+                      return OffsetTime.parse((CharSequence) instantInput);
                     }
                     if (instantInput instanceof StringValue) {
-                      return Instant.parse(((StringValue) instantInput).getValue());
+                      return OffsetTime.parse(((StringValue) instantInput).getValue());
                     }
                   } catch (DateTimeException exception) {
                     throw errorWrapper.apply(exception);
@@ -56,7 +56,7 @@ public class DateTimeScalar implements TypeFunction {
                   throw errorWrapper.apply(
                       new DateTimeException(
                           String.format(
-                              "Cannot convert provided format '%s' to Instant",
+                              "Cannot convert provided format '%s' to OffsetTime",
                               instantInput.getClass().getCanonicalName())));
                 }
               })
@@ -64,7 +64,7 @@ public class DateTimeScalar implements TypeFunction {
 
   @Override
   public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
-    return Instant.class.isAssignableFrom(aClass);
+    return OffsetTime.class.isAssignableFrom(aClass);
   }
 
   @Override
@@ -73,6 +73,6 @@ public class DateTimeScalar implements TypeFunction {
       Class<?> aClass,
       AnnotatedType annotatedType,
       ProcessingElementsContainer container) {
-    return DATE_TIME_SCALAR;
+    return OFFSET_TIME_SCALAR;
   }
 }

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/DateTimeScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/DateTimeScalarTest.java
@@ -8,11 +8,7 @@ import graphql.language.StringValue;
 import graphql.schema.GraphQLScalarType;
 import java.lang.reflect.AnnotatedType;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.chrono.ChronoLocalDateTime;
 import org.hypertrace.core.graphql.common.schema.typefunctions.DateTimeScalar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,11 +40,6 @@ class DateTimeScalarTest {
   @Test
   void canDetermineIfConvertible() {
     assertTrue(this.dateTimeFunction.canBuildType(Instant.class, this.mockAnnotatedType));
-    assertTrue(this.dateTimeFunction.canBuildType(OffsetDateTime.class, this.mockAnnotatedType));
-    assertTrue(this.dateTimeFunction.canBuildType(LocalDateTime.class, this.mockAnnotatedType));
-    assertTrue(
-        this.dateTimeFunction.canBuildType(ChronoLocalDateTime.class, this.mockAnnotatedType));
-    assertTrue(this.dateTimeFunction.canBuildType(ZonedDateTime.class, this.mockAnnotatedType));
   }
 
   @Test

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/OffsetTimeScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/OffsetTimeScalarTest.java
@@ -1,20 +1,20 @@
 package org.hypertrace.core.graphql.common.schema.scalars;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.language.StringValue;
 import graphql.schema.GraphQLScalarType;
+import java.lang.reflect.AnnotatedType;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import org.hypertrace.core.graphql.common.schema.typefunctions.OffsetTimeScalar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.lang.reflect.AnnotatedType;
-import java.time.OffsetTime;
-import java.time.ZoneOffset;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class OffsetTimeScalarTest {

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/OffsetTimeScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/OffsetTimeScalarTest.java
@@ -1,0 +1,72 @@
+package org.hypertrace.core.graphql.common.schema.scalars;
+
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.language.StringValue;
+import graphql.schema.GraphQLScalarType;
+import org.hypertrace.core.graphql.common.schema.typefunctions.OffsetTimeScalar;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.lang.reflect.AnnotatedType;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class OffsetTimeScalarTest {
+
+  private static final String TEST_SCALAR_TIME_STRING = "21:30:12.748+12:30";
+  private static final OffsetTime TEST_OFFSET_TIME = OffsetTime.parse(TEST_SCALAR_TIME_STRING);
+  private OffsetTimeScalar offsetTimeFunction;
+  private GraphQLScalarType offsetTimeType;
+  @Mock AnnotatedType mockAnnotatedType;
+  // Can't actually mock class, but it's not used so to convey intent using the Mock class.
+  private final Class<?> mockAnnotatedClass = Mock.class;
+  @Mock ProcessingElementsContainer mockProcessingElementsContainer;
+
+  @BeforeEach
+  void beforeEach() {
+    this.offsetTimeFunction = new OffsetTimeScalar();
+    // Can't actually mock class, but it's not used so to convey intent using
+    this.offsetTimeType =
+        this.offsetTimeFunction.buildType(
+            false, mockAnnotatedClass, mockAnnotatedType, mockProcessingElementsContainer);
+  }
+
+  @Test
+  void canDetermineIfConvertible() {
+    assertTrue(this.offsetTimeFunction.canBuildType(OffsetTime.class, this.mockAnnotatedType));
+  }
+
+  @Test
+  void canConvertFromLiteral() {
+    assertEquals(
+        TEST_OFFSET_TIME, offsetTimeType.getCoercing().parseLiteral(TEST_SCALAR_TIME_STRING));
+  }
+
+  @Test
+  void canSerialize() {
+    assertEquals(TEST_SCALAR_TIME_STRING, offsetTimeType.getCoercing().serialize(TEST_OFFSET_TIME));
+    assertEquals(
+        TEST_SCALAR_TIME_STRING, offsetTimeType.getCoercing().serialize(TEST_SCALAR_TIME_STRING));
+
+    assertEquals(
+        TEST_SCALAR_TIME_STRING,
+        offsetTimeType
+            .getCoercing()
+            .serialize(TEST_OFFSET_TIME.withOffsetSameLocal(ZoneOffset.ofHoursMinutes(12, 30))));
+  }
+
+  @Test
+  void canConvertFromValue() {
+    assertEquals(
+        TEST_OFFSET_TIME,
+        offsetTimeType
+            .getCoercing()
+            .parseValue(StringValue.newStringValue().value(TEST_SCALAR_TIME_STRING).build()));
+  }
+}


### PR DESCRIPTION
## Description
Add OffsetTime as Typefunction like DateTimeScalar

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
