### PR TITLE
Made OperatorConverter public and added a binding for the same.

### DIFF
--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/GatewayUtilsModule.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/GatewayUtilsModule.java
@@ -13,6 +13,7 @@ import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterOperatorType;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection;
 import org.hypertrace.core.graphql.common.utils.BiConverter;
@@ -22,6 +23,7 @@ import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.LiteralConstant;
+import org.hypertrace.gateway.service.v1.common.Operator;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.common.SortOrder;
 import org.hypertrace.gateway.service.v1.common.Value;
@@ -50,6 +52,8 @@ public class GatewayUtilsModule extends AbstractModule {
                     List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>>>() {}))
         .to(OrderByExpressionListConverter.class);
 
+    bind(Key.get(new TypeLiteral<Converter<FilterOperatorType, Operator>>() {}))
+        .to(OperatorConverter.class);
     bind(Key.get(
             new TypeLiteral<
                 Converter<Collection<AttributeAssociation<FilterArgument>>, Filter>>() {}))

--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
@@ -6,7 +6,7 @@ import org.hypertrace.core.graphql.common.schema.results.arguments.filter.Filter
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.gateway.service.v1.common.Operator;
 
-public class OperatorConverter implements Converter<FilterOperatorType, Operator> {
+class OperatorConverter implements Converter<FilterOperatorType, Operator> {
 
   @Override
   public Single<Operator> convert(FilterOperatorType filterOperatorType) {

--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
@@ -6,7 +6,7 @@ import org.hypertrace.core.graphql.common.schema.results.arguments.filter.Filter
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.gateway.service.v1.common.Operator;
 
-class OperatorConverter implements Converter<FilterOperatorType, Operator> {
+public class OperatorConverter implements Converter<FilterOperatorType, Operator> {
 
   @Override
   public Single<Operator> convert(FilterOperatorType filterOperatorType) {


### PR DESCRIPTION
Filter Operator Type Converter is required in many places and currently its code is being duplicated.
Added a guice binding so that it can be re-used by the consumers of gateway-service-utils.