### PR TITLE
ENG-17101: Support array types beyond string array in Literal converter

### DIFF
--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/LiteralConstantConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/LiteralConstantConverter.java
@@ -33,7 +33,8 @@ class LiteralConstantConverter implements Converter<Object, LiteralConstant> {
         .map(Builder::build);
   }
 
-  private Value convertValue(Optional<Object> optionalObject) {
+  private Value convertValue(
+      @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Object> optionalObject) {
     if (optionalObject.isEmpty()) {
       return Value.getDefaultInstance();
     }
@@ -43,31 +44,51 @@ class LiteralConstantConverter implements Converter<Object, LiteralConstant> {
 
     switch (valueType) {
       case LONG:
-        return valueBuilder.setLong(convertToLong(object)).build();
+        return valueBuilder.setLong(((Number) object).longValue()).build();
 
       case DOUBLE:
-        return valueBuilder.setDouble(convertToDouble(object)).build();
+        return valueBuilder.setDouble(((Number) object).doubleValue()).build();
 
       case BOOL:
-        return valueBuilder.setBoolean(convertToBoolean(object)).build();
+        return valueBuilder.setBoolean((Boolean) object).build();
 
       case TIMESTAMP:
-        return valueBuilder.setTimestamp(convertToTimestamp(object)).build();
+        return valueBuilder
+            .setTimestamp(Instant.from((TemporalAccessor) object).toEpochMilli())
+            .build();
 
       case BOOLEAN_ARRAY:
-        return valueBuilder.addAllBooleanArray(convertToBooleanCollection(object)).build();
+        return valueBuilder
+            .addAllBooleanArray(
+                ((Collection<?>) object)
+                    .stream().map(obj -> (Boolean) obj).collect(toUnmodifiableList()))
+            .build();
 
       case LONG_ARRAY:
-        return valueBuilder.addAllLongArray(convertToLongCollection(object)).build();
+        return valueBuilder
+            .addAllLongArray(
+                ((Collection<?>) object)
+                    .stream().map(obj -> ((Number) obj).longValue()).collect(toUnmodifiableList()))
+            .build();
 
       case DOUBLE_ARRAY:
-        return valueBuilder.addAllDoubleArray(convertToDoubleCollection(object)).build();
+        return valueBuilder
+            .addAllDoubleArray(
+                ((Collection<?>) object)
+                    .stream()
+                        .map(obj -> ((Number) obj).doubleValue())
+                        .collect(toUnmodifiableList()))
+            .build();
 
       case STRING_ARRAY:
-        return valueBuilder.addAllStringArray(convertToStringCollection(object)).build();
+        return valueBuilder
+            .addAllStringArray(
+                ((Collection<?>) object)
+                    .stream().map(String::valueOf).collect(toUnmodifiableList()))
+            .build();
     }
 
-    return valueBuilder.setString(convertToString(object)).build();
+    return valueBuilder.setString(String.valueOf(object)).build();
   }
 
   private boolean assignableToAnyOfClasses(Class<?> classToCheck, Class<?>... classesAllowed) {
@@ -119,44 +140,5 @@ class LiteralConstantConverter implements Converter<Object, LiteralConstant> {
     }
 
     return STRING_ARRAY;
-  }
-
-  private long convertToLong(final Object object) {
-    return ((Number) object).longValue();
-  }
-
-  private double convertToDouble(final Object object) {
-    return ((Number) object).doubleValue();
-  }
-
-  private boolean convertToBoolean(final Object object) {
-    return (Boolean) object;
-  }
-
-  private String convertToString(final Object object) {
-    return String.valueOf(object);
-  }
-
-  private long convertToTimestamp(final Object object) {
-    return Instant.from((TemporalAccessor) object).toEpochMilli();
-  }
-
-  private Collection<Long> convertToLongCollection(final Object object) {
-    return ((Collection<?>) object).stream().map(this::convertToLong).collect(toUnmodifiableList());
-  }
-
-  private Collection<Double> convertToDoubleCollection(final Object object) {
-    return ((Collection<?>) object)
-        .stream().map(this::convertToDouble).collect(toUnmodifiableList());
-  }
-
-  private Collection<Boolean> convertToBooleanCollection(final Object object) {
-    return ((Collection<?>) object)
-        .stream().map(this::convertToBoolean).collect(toUnmodifiableList());
-  }
-
-  private Collection<String> convertToStringCollection(final Object object) {
-    return ((Collection<?>) object)
-        .stream().map(this::convertToString).collect(toUnmodifiableList());
   }
 }

--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/LiteralConstantConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/LiteralConstantConverter.java
@@ -1,5 +1,16 @@
 package org.hypertrace.core.graphql.utils.gateway;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.hypertrace.gateway.service.v1.common.ValueType.BOOL;
+import static org.hypertrace.gateway.service.v1.common.ValueType.BOOLEAN_ARRAY;
+import static org.hypertrace.gateway.service.v1.common.ValueType.DOUBLE;
+import static org.hypertrace.gateway.service.v1.common.ValueType.DOUBLE_ARRAY;
+import static org.hypertrace.gateway.service.v1.common.ValueType.LONG;
+import static org.hypertrace.gateway.service.v1.common.ValueType.LONG_ARRAY;
+import static org.hypertrace.gateway.service.v1.common.ValueType.STRING;
+import static org.hypertrace.gateway.service.v1.common.ValueType.STRING_ARRAY;
+import static org.hypertrace.gateway.service.v1.common.ValueType.TIMESTAMP;
+
 import io.reactivex.rxjava3.core.Single;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -7,7 +18,6 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.gateway.service.v1.common.LiteralConstant;
 import org.hypertrace.gateway.service.v1.common.LiteralConstant.Builder;
@@ -15,7 +25,6 @@ import org.hypertrace.gateway.service.v1.common.Value;
 import org.hypertrace.gateway.service.v1.common.ValueType;
 
 class LiteralConstantConverter implements Converter<Object, LiteralConstant> {
-
   @Override
   public Single<LiteralConstant> convert(Object from) {
     return Single.just(Optional.ofNullable(from))
@@ -29,48 +38,125 @@ class LiteralConstantConverter implements Converter<Object, LiteralConstant> {
       return Value.getDefaultInstance();
     }
     Object object = optionalObject.get();
+    final ValueType valueType = getValueType(object);
+    final Value.Builder valueBuilder = Value.newBuilder().setValueType(valueType);
 
-    if (this.assignableToAnyOfClasses(
-        object.getClass(), Long.class, Integer.class, BigInteger.class)) {
-      return Value.newBuilder()
-          .setValueType(ValueType.LONG)
-          .setLong(((Number) object).longValue())
-          .build();
-    }
-    if (this.assignableToAnyOfClasses(object.getClass(), Number.class)) {
-      return Value.newBuilder()
-          .setValueType(ValueType.DOUBLE)
-          .setDouble(((Number) object).doubleValue())
-          .build();
-    }
-    if (this.assignableToAnyOfClasses(object.getClass(), Boolean.class)) {
-      return Value.newBuilder().setValueType(ValueType.BOOL).setBoolean((Boolean) object).build();
-    }
-    // todo handle Instant type object
-    if (this.assignableToAnyOfClasses(object.getClass(), TemporalAccessor.class)) {
-      return Value.newBuilder()
-          .setValueType(ValueType.TIMESTAMP)
-          .setTimestamp(Instant.from((TemporalAccessor) object).toEpochMilli())
-          .build();
-    }
-    if (this.assignableToAnyOfClasses(object.getClass(), Collection.class)) {
-      // TODO matches old impl, but probably should be expanded
-      return Value.newBuilder()
-          .setValueType(ValueType.STRING_ARRAY)
-          .addAllStringArray(
-              ((Collection<?>) object)
-                  .stream().map(String::valueOf).collect(Collectors.toUnmodifiableList()))
-          .build();
+    switch (valueType) {
+      case LONG:
+        return valueBuilder.setLong(convertToLong(object)).build();
+
+      case DOUBLE:
+        return valueBuilder.setDouble(convertToDouble(object)).build();
+
+      case BOOL:
+        return valueBuilder.setBoolean(convertToBoolean(object)).build();
+
+      case TIMESTAMP:
+        return valueBuilder.setTimestamp(convertToTimestamp(object)).build();
+
+      case BOOLEAN_ARRAY:
+        return valueBuilder.addAllBooleanArray(convertToBooleanCollection(object)).build();
+
+      case LONG_ARRAY:
+        return valueBuilder.addAllLongArray(convertToLongCollection(object)).build();
+
+      case DOUBLE_ARRAY:
+        return valueBuilder.addAllDoubleArray(convertToDoubleCollection(object)).build();
+
+      case STRING_ARRAY:
+        return valueBuilder.addAllStringArray(convertToStringCollection(object)).build();
     }
 
-    return Value.newBuilder()
-        .setValueType(ValueType.STRING)
-        .setString(String.valueOf(object))
-        .build();
+    return valueBuilder.setString(convertToString(object)).build();
   }
 
   private boolean assignableToAnyOfClasses(Class<?> classToCheck, Class<?>... classesAllowed) {
     return Arrays.stream(classesAllowed)
         .anyMatch(allowedClass -> allowedClass.isAssignableFrom(classToCheck));
+  }
+
+  private ValueType getValueType(final Object object) {
+    if (this.assignableToAnyOfClasses(
+        object.getClass(), Long.class, Integer.class, BigInteger.class)) {
+      return LONG;
+    }
+    if (this.assignableToAnyOfClasses(object.getClass(), Number.class)) {
+      return DOUBLE;
+    }
+    if (this.assignableToAnyOfClasses(object.getClass(), Boolean.class)) {
+      return BOOL;
+    }
+    // todo handle Instant type object
+    if (this.assignableToAnyOfClasses(object.getClass(), TemporalAccessor.class)) {
+      return TIMESTAMP;
+    }
+
+    if (this.assignableToAnyOfClasses(object.getClass(), Collection.class)) {
+      return getCollectionType(object);
+    }
+
+    return STRING;
+  }
+
+  private ValueType getCollectionType(final Object object) {
+    final Collection<?> collection = (Collection<?>) object;
+    if (collection.isEmpty()) {
+      return STRING_ARRAY;
+    }
+
+    final Object first = collection.iterator().next();
+    final ValueType baseType = getValueType(first);
+
+    switch (baseType) {
+      case BOOL:
+        return BOOLEAN_ARRAY;
+
+      case LONG:
+        return LONG_ARRAY;
+
+      case DOUBLE:
+        return DOUBLE_ARRAY;
+    }
+
+    return STRING_ARRAY;
+  }
+
+  private long convertToLong(final Object object) {
+    return ((Number) object).longValue();
+  }
+
+  private double convertToDouble(final Object object) {
+    return ((Number) object).doubleValue();
+  }
+
+  private boolean convertToBoolean(final Object object) {
+    return (Boolean) object;
+  }
+
+  private String convertToString(final Object object) {
+    return String.valueOf(object);
+  }
+
+  private long convertToTimestamp(final Object object) {
+    return Instant.from((TemporalAccessor) object).toEpochMilli();
+  }
+
+  private Collection<Long> convertToLongCollection(final Object object) {
+    return ((Collection<?>) object).stream().map(this::convertToLong).collect(toUnmodifiableList());
+  }
+
+  private Collection<Double> convertToDoubleCollection(final Object object) {
+    return ((Collection<?>) object)
+        .stream().map(this::convertToDouble).collect(toUnmodifiableList());
+  }
+
+  private Collection<Boolean> convertToBooleanCollection(final Object object) {
+    return ((Collection<?>) object)
+        .stream().map(this::convertToBoolean).collect(toUnmodifiableList());
+  }
+
+  private Collection<String> convertToStringCollection(final Object object) {
+    return ((Collection<?>) object)
+        .stream().map(this::convertToString).collect(toUnmodifiableList());
   }
 }

--- a/hypertrace-core-graphql-gateway-service-utils/src/test/java/org/hypertrace/core/graphql/utils/gateway/LiteralConstantConverterTest.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/test/java/org/hypertrace/core/graphql/utils/gateway/LiteralConstantConverterTest.java
@@ -34,6 +34,15 @@ class LiteralConstantConverterTest {
 
     assertEquals(
         LiteralConstant.newBuilder()
+            .setValue(
+                Value.newBuilder()
+                    .setValueType(ValueType.BOOLEAN_ARRAY)
+                    .addAllBooleanArray(List.of(true, false)))
+            .build(),
+        converter.convert(List.of(true, false)).blockingGet());
+
+    assertEquals(
+        LiteralConstant.newBuilder()
             .setValue(Value.newBuilder().setValueType(ValueType.LONG).setLong(100))
             .build(),
         converter.convert(100L).blockingGet());


### PR DESCRIPTION
## Description

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit test.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
