### PR TITLE
Support for GrpcChannelConfig in GrpcChannelRegistry

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,9 +6,5 @@ ignore:
     - '*':
         reason: No replacement available
         expires: 2022-07-31T00:00:00.000Z
-  SNYK-JAVA-IONETTY-2812456:
-    - '*':
-        reason: No replacement available
-        expires: 2023-05-31T00:00:00.000Z
 patch: {}
 

--- a/.snyk
+++ b/.snyk
@@ -6,5 +6,9 @@ ignore:
     - '*':
         reason: No replacement available
         expires: 2022-07-31T00:00:00.000Z
+  SNYK-JAVA-IONETTY-2812456:
+    - '*':
+        reason: No replacement available
+        expires: 2023-05-31T00:00:00.000Z
 patch: {}
 

--- a/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/DefaultGrpcChannelRegistry.java
+++ b/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/DefaultGrpcChannelRegistry.java
@@ -4,6 +4,7 @@ import io.grpc.ManagedChannel;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.hypertrace.core.graphql.spi.lifecycle.GraphQlServiceLifecycle;
+import org.hypertrace.core.grpcutils.client.GrpcChannelConfig;
 
 @Singleton
 class DefaultGrpcChannelRegistry implements GrpcChannelRegistry {
@@ -19,5 +20,10 @@ class DefaultGrpcChannelRegistry implements GrpcChannelRegistry {
   @Override
   public ManagedChannel forAddress(String host, int port) {
     return this.delegate.forPlaintextAddress(host, port);
+  }
+
+  @Override
+  public ManagedChannel forAddress(String host, int port, GrpcChannelConfig channelConfig) {
+    return this.delegate.forPlaintextAddress(host, port, channelConfig);
   }
 }

--- a/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/GrpcChannelRegistry.java
+++ b/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/GrpcChannelRegistry.java
@@ -1,7 +1,11 @@
 package org.hypertrace.core.graphql.utils.grpc;
 
 import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import org.hypertrace.core.grpcutils.client.GrpcChannelConfig;
 
 public interface GrpcChannelRegistry {
   Channel forAddress(String host, int port);
+
+  ManagedChannel forAddress(String host, int port, GrpcChannelConfig channelConfig);
 }

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     }
 
     runtime("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
-    runtime("io.grpc:grpc-netty:1.45.1")
+    runtime("io.grpc:grpc-netty:1.46.0")
     runtime("io.netty:netty-codec-http2:4.1.71.Final")
     runtime("io.netty:netty-handler-proxy:4.1.71.Final")
   }

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 dependencies {
   constraints {
 
-    api("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.2")
-    api("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.2")
-    api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.2")
+    api("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.3")
+    api("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.3")
+    api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.3")
     api("org.hypertrace.gateway.service:gateway-service-api:0.2.0")
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.13.6")
 
@@ -40,7 +40,7 @@ dependencies {
     }
 
     runtime("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
-    runtime("io.grpc:grpc-netty:1.46.0")
+    runtime("io.grpc:grpc-netty:1.45.1")
     runtime("io.netty:netty-codec-http2:4.1.71.Final")
     runtime("io.netty:netty-handler-proxy:4.1.71.Final")
   }


### PR DESCRIPTION
## Description
Add support for optional configuration support to GrpcChannel

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->



### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
