### PR TITLE
feat: parallelize requests by default

### DIFF
--- a/helm/templates/serviceconfig.yaml
+++ b/helm/templates/serviceconfig.yaml
@@ -17,6 +17,9 @@ data:
     graphql.urlPath = {{ .Values.serviceConfig.urlPath }}
     graphql.corsEnabled = {{ .Values.serviceConfig.corsEnabled }}
     graphql.timeout = {{ .Values.serviceConfig.timeoutDuration }}
+    
+    threads.io.max = {{ .Values.serviceConfig.threads.io }}
+    threads.request.max = {{ .Values.serviceConfig.threads.request }}
 
     attribute.service = {
       host = {{ .Values.serviceConfig.attributeService.host }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -46,6 +46,9 @@ serviceConfig:
   corsEnabled: true
   defaultTenantId: ""
   timeoutDuration: 30s
+  threads:
+    io: 10
+    request: 10
   attributeService:
     host: attribute-service
     port: 9012

--- a/hypertrace-core-graphql-context/build.gradle.kts
+++ b/hypertrace-core-graphql-context/build.gradle.kts
@@ -12,6 +12,9 @@ dependencies {
   implementation(project(":hypertrace-core-graphql-spi"))
   implementation("com.google.guava:guava")
 
+  annotationProcessor("org.projectlombok:lombok")
+  compileOnly("org.projectlombok:lombok")
+
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.mockito:mockito-core")
   testImplementation("org.mockito:mockito-junit-jupiter")

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/AsyncDataFetcherFactory.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/AsyncDataFetcherFactory.java
@@ -1,0 +1,63 @@
+package org.hypertrace.core.graphql.context;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Injector;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.AllArgsConstructor;
+import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
+
+@Singleton
+class AsyncDataFetcherFactory {
+
+  private final Injector injector;
+  private final GraphQlServiceConfig config;
+  private final ExecutorService requestExecutor;
+
+  @Inject
+  AsyncDataFetcherFactory(Injector injector, GraphQlServiceConfig config) {
+    this.injector = injector;
+    this.config = config;
+    this.requestExecutor =
+        Executors.newFixedThreadPool(
+            config.getMaxRequestThreads(),
+            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("request-handler-%d").build());
+  }
+
+  <T> DataFetcher<CompletableFuture<T>> buildDataFetcher(
+      Class<? extends DataFetcher<CompletableFuture<T>>> dataFetcherClass) {
+    return new AsyncForwardingDataFetcher<>(
+        this.injector.getInstance(dataFetcherClass), requestExecutor, config);
+  }
+
+  @AllArgsConstructor
+  private static class AsyncForwardingDataFetcher<T> implements DataFetcher<CompletableFuture<T>> {
+    private final DataFetcher<CompletableFuture<T>> delegate;
+    private final ExecutorService executorService;
+    private final GraphQlServiceConfig config;
+
+    @Override
+    public CompletableFuture<T> get(DataFetchingEnvironment dataFetchingEnvironment)
+        throws Exception {
+      // Really all we're doing here is changing the thread that the future is run on by default
+      return CompletableFuture.supplyAsync(
+          () -> {
+            try {
+              return delegate
+                  .get(dataFetchingEnvironment)
+                  .get(config.getGraphQlTimeout().toMillis(), MILLISECONDS);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          },
+          executorService);
+    }
+  }
+}

--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
@@ -4,6 +4,7 @@ import graphql.kickstart.execution.context.GraphQLContext;
 import graphql.schema.DataFetcher;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 
 public interface GraphQlRequestContext extends GraphQLContext {
@@ -12,7 +13,8 @@ public interface GraphQlRequestContext extends GraphQLContext {
    * A tool to create data fetchers via injection container due to limitations in the framework. For
    * normal injectable instantiation, do not use this method.
    */
-  <T extends DataFetcher<?>> T constructDataFetcher(Class<T> dataFetcherClass);
+  <T> DataFetcher<CompletableFuture<T>> constructDataFetcher(
+      Class<? extends DataFetcher<CompletableFuture<T>>> dataFetcherClass);
 
   Optional<String> getAuthorizationHeader();
 

--- a/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/AsyncDataFetcherFactoryTest.java
+++ b/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/AsyncDataFetcherFactoryTest.java
@@ -1,0 +1,40 @@
+package org.hypertrace.core.graphql.context;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Guice;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncDataFetcherFactoryTest {
+  @Mock GraphQlServiceConfig graphQlServiceConfig;
+  @Mock DataFetchingEnvironment dataFetchingEnvironment;
+
+  @Test
+  void canBuildAsyncDataFetcher() throws Exception {
+    when(graphQlServiceConfig.getMaxRequestThreads()).thenReturn(1);
+    DataFetcher<CompletableFuture<Thread>> fetcher =
+        new AsyncDataFetcherFactory(Guice.createInjector(), graphQlServiceConfig)
+            .buildDataFetcher(ThreadEchoingDataFetcher.class);
+
+    Thread fetcherThread = fetcher.get(dataFetchingEnvironment).get();
+
+    assertNotEquals(Thread.currentThread(), fetcherThread);
+    assertNotNull(fetcherThread);
+  }
+
+  private static class ThreadEchoingDataFetcher implements DataFetcher<CompletableFuture<Thread>> {
+    @Override
+    public CompletableFuture<Thread> get(DataFetchingEnvironment environment) {
+      return CompletableFuture.completedFuture(Thread.currentThread());
+    }
+  }
+}

--- a/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-service/src/main/java/org/hypertrace/core/graphql/service/DefaultGraphQlServiceConfig.java
@@ -20,6 +20,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private static final String DEFAULT_TENANT_ID = "defaultTenantId";
 
   private static final String MAX_IO_THREADS_PROPERTY = "threads.io.max";
+  private static final String MAX_REQUEST_THREADS_PROPERTY = "threads.request.max";
 
   private static final String ATTRIBUTE_SERVICE_HOST_PROPERTY = "attribute.service.host";
   private static final String ATTRIBUTE_SERVICE_PORT_PROPERTY = "attribute.service.port";
@@ -36,6 +37,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   private final Duration graphQlTimeout;
   private final Optional<String> defaultTenantId;
   private final int maxIoThreads;
+  private final int maxRequestThreads;
   private final String attributeServiceHost;
   private final int attributeServicePort;
   private final Duration attributeServiceTimeout;
@@ -51,6 +53,7 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
     this.graphQlTimeout = untypedConfig.getDuration(GRAPHQL_TIMEOUT);
     this.defaultTenantId = optionallyGet(() -> untypedConfig.getString(DEFAULT_TENANT_ID));
     this.maxIoThreads = untypedConfig.getInt(MAX_IO_THREADS_PROPERTY);
+    this.maxRequestThreads = untypedConfig.getInt(MAX_REQUEST_THREADS_PROPERTY);
 
     this.attributeServiceHost = untypedConfig.getString(ATTRIBUTE_SERVICE_HOST_PROPERTY);
     this.attributeServicePort = untypedConfig.getInt(ATTRIBUTE_SERVICE_PORT_PROPERTY);
@@ -96,6 +99,11 @@ class DefaultGraphQlServiceConfig implements GraphQlServiceConfig {
   @Override
   public int getMaxIoThreads() {
     return maxIoThreads;
+  }
+
+  @Override
+  public int getMaxRequestThreads() {
+    return maxRequestThreads;
   }
 
   @Override

--- a/hypertrace-core-graphql-service/src/main/resources/configs/common/application.conf
+++ b/hypertrace-core-graphql-service/src/main/resources/configs/common/application.conf
@@ -8,6 +8,7 @@ graphql.corsEnabled = true
 graphql.timeout = 30s
 
 threads.io.max = 10
+threads.request.max = 10
 
 attribute.service = {
   host = localhost

--- a/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
+++ b/hypertrace-core-graphql-spi/src/main/java/org/hypertrace/core/graphql/spi/config/GraphQlServiceConfig.java
@@ -17,6 +17,8 @@ public interface GraphQlServiceConfig {
 
   Optional<String> getDefaultTenantId();
 
+  int getMaxRequestThreads();
+
   int getMaxIoThreads();
 
   String getAttributeServiceHost();


### PR DESCRIPTION
## Description
By default graphql-java does not create threads. The container may create separate threads for different requests, and some of our implementations create threads to parallelize within a data fetcher, but if multiple queries come in the same HTTP request (batch), each will be executed in serial on the same thread by default.

With this change, we use a configurable thread pool to hand off execution at the GQL query level, rather than the HTTP request level.


### Testing
Tested E2E as well as adding UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

