### PR TITLE
feat: add CONTAINS_KEY_LIKE operator

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/FilterOperatorType.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/FilterOperatorType.java
@@ -14,7 +14,8 @@ public enum FilterOperatorType {
   IN,
   NOT_IN,
   CONTAINS_KEY,
-  CONTAINS_KEY_VALUE;
+  CONTAINS_KEY_VALUE,
+  CONTAINS_KEY_LIKE;
 
   public static final String TYPE_NAME = "FilterOperatorType";
 }

--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
@@ -33,6 +33,8 @@ class OperatorConverter implements Converter<FilterOperatorType, Operator> {
         return Single.just(Operator.CONTAINS_KEY);
       case CONTAINS_KEY_VALUE:
         return Single.just(Operator.CONTAINS_KEYVALUE);
+      case CONTAINS_KEY_LIKE:
+        return Single.just(Operator.CONTAINS_KEY_LIKE);
       default:
         return Single.error(
             new UnknownFormatConversionException(

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.4")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.4")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.4")
-    api("org.hypertrace.gateway.service:gateway-service-api:0.2.0")
+    api("org.hypertrace.gateway.service:gateway-service-api:0.2.10")
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.13.6")
 
     api("com.google.inject:guice:5.1.0")


### PR DESCRIPTION
## Description
Propagating the changes from gateway-service(https://github.com/hypertrace/gateway-service/pull/136) to here, this PR adds `CONTAINS_KEY_LIKE` operator for doing a regex based search on map fields (on map key column).

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->