### PR TITLE
refactor: add ability to restore context

### DIFF
--- a/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/GrpcContextBuilder.java
+++ b/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/GrpcContextBuilder.java
@@ -1,8 +1,11 @@
 package org.hypertrace.core.graphql.utils.grpc;
 
+import java.util.Optional;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 
 public interface GrpcContextBuilder {
   RequestContext build(GraphQlRequestContext requestContext);
+
+  Optional<GraphQlRequestContext> tryRestore(RequestContext requestContext);
 }

--- a/hypertrace-core-graphql-grpc-utils/src/test/java/org/hypertrace/core/graphql/utils/grpc/PlatformGrpcContextBuilderTest.java
+++ b/hypertrace-core-graphql-grpc-utils/src/test/java/org/hypertrace/core/graphql/utils/grpc/PlatformGrpcContextBuilderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import java.util.Optional;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -60,5 +61,13 @@ class PlatformGrpcContextBuilderTest {
     assertEquals(
         "auth header",
         this.builder.build(this.mockRequestContext).getRequestHeaders().get("authorization"));
+  }
+
+  @Test
+  void testRestoreContext() {
+    when(this.mockRequestContext.getRequestId()).thenReturn("request id");
+    RequestContext resultContext = this.builder.build(this.mockRequestContext);
+    assertEquals(Optional.empty(), this.builder.tryRestore(RequestContext.forTenantId("other")));
+    assertEquals(Optional.of(this.mockRequestContext), this.builder.tryRestore(resultContext));
   }
 }


### PR DESCRIPTION
## Description
Added the ability to restore the graphql request context from the grpc context. This is required for grpc instrumentation and interceptors which do not give direct access to the graphql context.

### Testing
Updated unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
