### PR TITLE
fix: make stateful builder singleton, upgrade context

### DIFF
--- a/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/PlatformGrpcContextBuilder.java
+++ b/hypertrace-core-graphql-grpc-utils/src/main/java/org/hypertrace/core/graphql/utils/grpc/PlatformGrpcContextBuilder.java
@@ -14,9 +14,11 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.inject.Singleton;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 
+@Singleton
 class PlatformGrpcContextBuilder implements GrpcContextBuilder {
 
   private final Cache<String, GraphQlRequestContext> contextCache =

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
   api(platform("io.grpc:grpc-bom:1.47.0"))
   constraints {
 
-    api("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.7")
-    api("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.7")
-    api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.7")
-    api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.7.7")
+    api("org.hypertrace.core.grpcutils:grpc-context-utils:0.8.0")
+    api("org.hypertrace.core.grpcutils:grpc-client-utils:0.8.0")
+    api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.8.0")
+    api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.8.0")
     api("org.hypertrace.gateway.service:gateway-service-api:0.2.13")
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.14.8")
 


### PR DESCRIPTION
## Description
Builder updates give it state, so making it a singleton. Also upgrading grpc context to improve logging and claim access.

### Testing
Verified E2E