### PR TITLE
refactor: update core gql libs

### DIFF
--- a/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
+++ b/hypertrace-core-graphql-context/src/main/java/org/hypertrace/core/graphql/context/GraphQlRequestContext.java
@@ -1,13 +1,13 @@
 package org.hypertrace.core.graphql.context;
 
-import graphql.kickstart.execution.context.GraphQLContext;
+import graphql.kickstart.execution.context.GraphQLKickstartContext;
 import graphql.schema.DataFetcher;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 
-public interface GraphQlRequestContext extends GraphQLContext {
+public interface GraphQlRequestContext extends GraphQLKickstartContext {
 
   /**
    * A tool to create data fetchers via injection container due to limitations in the framework. For

--- a/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
+++ b/hypertrace-core-graphql-context/src/test/java/org/hypertrace/core/graphql/context/DefaultGraphQlRequestContextBuilderTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
@@ -67,7 +66,7 @@ class DefaultGraphQlRequestContextBuilderTest {
 
   @Test
   void delegatesDataLoaderRegistry() {
-    assertTrue(this.requestContext.getDataLoaderRegistry().isPresent());
+    assertNotNull(this.requestContext.getDataLoaderRegistry());
   }
 
   @Test

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -18,8 +18,8 @@ dependencies {
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.14.8")
 
     api("com.google.inject:guice:5.1.0")
-    api("com.graphql-java:graphql-java:15.0")
-    api("io.github.graphql-java:graphql-java-annotations:8.3")
+    api("com.graphql-java:graphql-java:19.2")
+    api("io.github.graphql-java:graphql-java-annotations:9.1")
     api("org.slf4j:slf4j-api:1.7.36")
     api("io.reactivex.rxjava3:rxjava:3.1.5")
     api("com.google.protobuf:protobuf-java-util:3.21.1")
@@ -28,7 +28,7 @@ dependencies {
     api("com.google.code.findbugs:jsr305:3.0.2")
     api("com.typesafe:config:1.4.2")
     api("com.google.guava:guava:31.1-jre")
-    api("com.graphql-java-kickstart:graphql-java-servlet:10.1.0")
+    api("com.graphql-java-kickstart:graphql-java-servlet:14.0.0")
 
     api("com.fasterxml.jackson.core:jackson-databind:2.13.4")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4")

--- a/hypertrace-core-graphql-schema-registry/src/main/java/org/hypertrace/core/graphql/schema/registry/DefaultGraphQlSchemaRegistry.java
+++ b/hypertrace-core-graphql-schema-registry/src/main/java/org/hypertrace/core/graphql/schema/registry/DefaultGraphQlSchemaRegistry.java
@@ -22,7 +22,7 @@ class DefaultGraphQlSchemaRegistry implements GraphQlSchemaRegistry {
   }
 
   @Override
-  public GraphQlSchemaFragment getRootFragment() {
+  public DefaultSchema getRootFragment() {
     return this.defaultSchemaFragment;
   }
 }

--- a/hypertrace-core-graphql-schema-registry/src/main/java/org/hypertrace/core/graphql/schema/registry/DefaultSchema.java
+++ b/hypertrace-core-graphql-schema-registry/src/main/java/org/hypertrace/core/graphql/schema/registry/DefaultSchema.java
@@ -1,9 +1,17 @@
 package org.hypertrace.core.graphql.schema.registry;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.hypertrace.core.graphql.spi.schema.GraphQlSchemaFragment;
 
 class DefaultSchema implements GraphQlSchemaFragment {
+  // Placeholder description is used to identify and remove placeholder fields before building the
+  // schema. Placeholders are used while the schema is under construction so it is always valid
+  // (i.e. has at least one value)
+  static final String PLACEHOLDER_DESCRIPTION = "::placeholder::";
+  static final String ROOT_QUERY_NAME = "Query";
+  static final String ROOT_MUTATION_NAME = "Mutation";
 
   @Override
   public String fragmentName() {
@@ -20,9 +28,17 @@ class DefaultSchema implements GraphQlSchemaFragment {
     return MutationSchema.class;
   }
 
-  @GraphQLName("Query")
-  private interface QuerySchema {}
+  @GraphQLName(ROOT_QUERY_NAME)
+  private interface QuerySchema {
+    @GraphQLField
+    @GraphQLDescription(PLACEHOLDER_DESCRIPTION)
+    String placeholder();
+  }
 
-  @GraphQLName("Mutation")
-  private interface MutationSchema {}
+  @GraphQLName(ROOT_MUTATION_NAME)
+  private interface MutationSchema {
+    @GraphQLField
+    @GraphQLDescription(PLACEHOLDER_DESCRIPTION)
+    String placeholder();
+  }
 }


### PR DESCRIPTION
## Description
Updating the main GQL libs, which included a few breaking changes. The two main ones here are

- Schema Validation now requires every object to have at least one type. This makes sense, but causes issues with how we build partial schemas then merge them. Sidestepped the issue by adding placeholders to root schema so every partial schema passes validation, then stripping them out at the end (before validating one last time).
- The Context types were renamed and move around a bit. A few types were changed and fields removed. Updated our context based off it to extend the built in one and adjusted things here a bit.

### Testing
Unit and ran E2E


