### PR TITLE
refactor: add a way to rebuild a rs request with new filters

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequestBuilder.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequestBuilder.java
@@ -39,6 +39,9 @@ public interface ResultSetRequestBuilder {
       Stream<SelectedField> attributeQueryableFields,
       Optional<String> spaceId);
 
+  <O extends OrderArgument> Single<ResultSetRequest<O>> rebuildWithAdditionalFilters(
+      ResultSetRequest<O> originalRequest, Collection<FilterArgument> additionalFilters);
+
   Single<ResultSetRequest<OrderArgument>> build(
       GraphQlRequestContext context,
       String requestScope,


### PR DESCRIPTION
## Description
Expose a way to rebuild a result set request with extra filters. this makes it easy to, for example, add interceptors that apply mandatory filters.
