### PR TITLE
fix: unknown scalar not handling variable values

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/UnknownScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/UnknownScalarTest.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.graphql.common.schema.scalars;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import graphql.annotations.processor.ProcessingElementsContainer;
@@ -10,6 +11,7 @@ import graphql.language.BooleanValue;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
+import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.GraphQLScalarType;
 import java.lang.reflect.AnnotatedType;
 import java.math.BigDecimal;
@@ -92,5 +94,21 @@ class UnknownScalarTest {
                 ArrayValue.newArrayValue()
                     .value(StringValue.newStringValue("five").build())
                     .build()));
+
+    assertThrows(
+        CoercingParseLiteralException.class,
+        () -> unknownScalarType.getCoercing().parseLiteral("bad value"));
+  }
+
+  @Test
+  void canConvertFromValue() {
+    // A dumb bug requires a dumb test
+    assertEquals(true, unknownScalarType.getCoercing().parseValue(true));
+
+    assertEquals("value", unknownScalarType.getCoercing().parseValue("value"));
+
+    assertEquals(10, unknownScalarType.getCoercing().parseValue(10));
+
+    assertEquals(10.5, unknownScalarType.getCoercing().parseValue(10.5));
   }
 }


### PR DESCRIPTION
## Description
The parseValue version of the unknown scalar was not correctly handling the raw values that are given when using a variable for an unknown value. It treated all inputs as AST objects. It now echos them back out, as unknown values have no specific type and they're left to the code to determine. Also fixed a buck where an error was returned rather than thrown which was hiding this issue in the past.


### Testing
Added Unit tests and verified in local instance

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
