### PR TITLE
refactor: expose not contains key operator

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/FilterOperatorType.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/FilterOperatorType.java
@@ -15,7 +15,8 @@ public enum FilterOperatorType {
   NOT_IN,
   CONTAINS_KEY,
   CONTAINS_KEY_VALUE,
-  CONTAINS_KEY_LIKE;
+  CONTAINS_KEY_LIKE,
+  NOT_CONTAINS_KEY;
 
   public static final String TYPE_NAME = "FilterOperatorType";
 }

--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/OperatorConverter.java
@@ -31,6 +31,8 @@ class OperatorConverter implements Converter<FilterOperatorType, Operator> {
         return Single.just(Operator.LIKE);
       case CONTAINS_KEY:
         return Single.just(Operator.CONTAINS_KEY);
+      case NOT_CONTAINS_KEY:
+        return Single.just(Operator.NOT_CONTAINS_KEY);
       case CONTAINS_KEY_VALUE:
         return Single.just(Operator.CONTAINS_KEYVALUE);
       case CONTAINS_KEY_LIKE:

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.11.2")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.11.2")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.11.2")
-    api("org.hypertrace.gateway.service:gateway-service-api:0.2.24")
+    api("org.hypertrace.gateway.service:gateway-service-api:0.2.25")
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:${attributeServiceVersion}")
     api("org.hypertrace.core.attribute.service:attribute-service-api:${attributeServiceVersion}")
 


### PR DESCRIPTION
## Description

NOT CONTAINS KEY operators on map attributes to check for (lack of) key presence. 

Depends on https://github.com/hypertrace/gateway-service/pull/162 being merged and published.