### PR TITLE
feat: adding consumer support for new traces/spans api

### DIFF
--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     api("org.hypertrace.core.grpcutils:grpc-context-utils:0.12.1")
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.1")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.12.1")
-    api("org.hypertrace.gateway.service:gateway-service-api:0.2.25")
+    api("org.hypertrace.gateway.service:gateway-service-api:0.3.0-SNAPSHOT")
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:${attributeServiceVersion}")
     api("org.hypertrace.core.attribute.service:attribute-service-api:${attributeServiceVersion}")
 

--- a/hypertrace-core-graphql-platform/build.gradle.kts
+++ b/hypertrace-core-graphql-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     api("org.hypertrace.core.grpcutils:grpc-context-utils:0.12.1")
     api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.1")
     api("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.12.1")
-    api("org.hypertrace.gateway.service:gateway-service-api:0.3.0-SNAPSHOT")
+    api("org.hypertrace.gateway.service:gateway-service-api:0.3.0")
     api("org.hypertrace.core.attribute.service:caching-attribute-service-client:${attributeServiceVersion}")
     api("org.hypertrace.core.attribute.service:attribute-service-api:${attributeServiceVersion}")
 

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanConverter.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanConverter.java
@@ -34,7 +34,7 @@ class GatewayServiceSpanConverter {
   }
 
   public Single<SpanResultSet> convert(SpanRequest request, SpanLogEventsResponse response) {
-    int total = response.spansResponse().getTotal();
+    int total = response.spansResponse().hasTotal() ? response.spansResponse().getTotal() : 0;
 
     return Observable.fromIterable(response.spansResponse().getSpansList())
         .flatMapSingle(spanEvent -> this.convert(request, spanEvent, response.spanIdToLogEvents()))

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanRequestBuilder.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanRequestBuilder.java
@@ -56,6 +56,7 @@ class GatewayServiceSpanRequestBuilder {
                         .spanEventsRequest()
                         .spaceId()
                         .orElse("")) // String proto default value
+                .setFetchTotal(gqlRequest.fetchTotal())
                 .build());
   }
 }

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/request/DefaultSpanRequestBuilder.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/request/DefaultSpanRequestBuilder.java
@@ -74,6 +74,9 @@ class DefaultSpanRequestBuilder implements SpanRequestBuilder {
             context, HypertraceCoreAttributeScopeString.SPAN, arguments, spanAttributeExpressions),
         logEventAttributeRequestBuilder.buildAttributeRequest(context, logAttributeExpressions),
         (resultSetRequest, logEventAttributeRequest) ->
+            // This build method is utilized in the exportSpans API, which does not accept the total
+            // parameter as an argument. Ref {@link ExportSpanResult}.
+            // So, we explicitly set fetchTotal to false.
             new DefaultSpanRequest(context, resultSetRequest, logEventAttributeRequest, false));
   }
 

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/request/DefaultSpanRequestBuilder.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/request/DefaultSpanRequestBuilder.java
@@ -15,20 +15,26 @@ import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.request.ResultSetRequest;
 import org.hypertrace.core.graphql.common.request.ResultSetRequestBuilder;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
+import org.hypertrace.core.graphql.common.schema.results.ResultSet;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.core.graphql.utils.schema.GraphQlSelectionFinder;
+import org.hypertrace.core.graphql.utils.schema.SelectionQuery;
 
 class DefaultSpanRequestBuilder implements SpanRequestBuilder {
 
   private final ResultSetRequestBuilder resultSetRequestBuilder;
   private final LogEventAttributeRequestBuilder logEventAttributeRequestBuilder;
+  private final GraphQlSelectionFinder selectionFinder;
 
   @Inject
   public DefaultSpanRequestBuilder(
       ResultSetRequestBuilder resultSetRequestBuilder,
-      LogEventAttributeRequestBuilder logEventAttributeRequestBuilder) {
+      LogEventAttributeRequestBuilder logEventAttributeRequestBuilder,
+      GraphQlSelectionFinder selectionFinder) {
     this.resultSetRequestBuilder = resultSetRequestBuilder;
     this.logEventAttributeRequestBuilder = logEventAttributeRequestBuilder;
+    this.selectionFinder = selectionFinder;
   }
 
   @Override
@@ -36,6 +42,13 @@ class DefaultSpanRequestBuilder implements SpanRequestBuilder {
       GraphQlRequestContext context,
       Map<String, Object> arguments,
       DataFetchingFieldSelectionSet selectionSet) {
+    boolean fetchTotal =
+        this.selectionFinder
+                .findSelections(
+                    selectionSet, SelectionQuery.namedChild(ResultSet.RESULT_SET_TOTAL_NAME))
+                .count()
+            > 0;
+
     return zip(
         resultSetRequestBuilder.build(
             context,
@@ -45,7 +58,8 @@ class DefaultSpanRequestBuilder implements SpanRequestBuilder {
             OrderArgument.class),
         logEventAttributeRequestBuilder.buildAttributeRequest(context, selectionSet),
         (resultSetRequest, logEventAttributeRequest) ->
-            new DefaultSpanRequest(context, resultSetRequest, logEventAttributeRequest));
+            new DefaultSpanRequest(
+                context, resultSetRequest, logEventAttributeRequest, fetchTotal));
   }
 
   @Override
@@ -54,12 +68,13 @@ class DefaultSpanRequestBuilder implements SpanRequestBuilder {
       Map<String, Object> arguments,
       List<AttributeExpression> spanAttributeExpressions,
       List<AttributeExpression> logAttributeExpressions) {
+
     return zip(
         resultSetRequestBuilder.build(
             context, HypertraceCoreAttributeScopeString.SPAN, arguments, spanAttributeExpressions),
         logEventAttributeRequestBuilder.buildAttributeRequest(context, logAttributeExpressions),
         (resultSetRequest, logEventAttributeRequest) ->
-            new DefaultSpanRequest(context, resultSetRequest, logEventAttributeRequest));
+            new DefaultSpanRequest(context, resultSetRequest, logEventAttributeRequest, false));
   }
 
   @Value
@@ -68,5 +83,6 @@ class DefaultSpanRequestBuilder implements SpanRequestBuilder {
     GraphQlRequestContext context;
     ResultSetRequest<OrderArgument> spanEventsRequest;
     Collection<AttributeRequest> logEventAttributes;
+    boolean fetchTotal;
   }
 }

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/request/SpanRequest.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/request/SpanRequest.java
@@ -10,4 +10,6 @@ public interface SpanRequest extends ContextualRequest {
   ResultSetRequest<OrderArgument> spanEventsRequest();
 
   Collection<AttributeRequest> logEventAttributes();
+
+  boolean fetchTotal();
 }

--- a/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/DaoTestUtil.java
+++ b/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/DaoTestUtil.java
@@ -72,6 +72,7 @@ class DaoTestUtil {
     GraphQlRequestContext context;
     ResultSetRequest<OrderArgument> spanEventsRequest;
     Collection<AttributeRequest> logEventAttributes;
+    boolean fetchTotal;
   }
 
   @Value

--- a/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/SpanLogEventRequestBuilderTest.java
+++ b/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/SpanLogEventRequestBuilderTest.java
@@ -152,7 +152,8 @@ class SpanLogEventRequestBuilderTest {
             List.of(),
             Collections.emptyList(),
             Optional.empty());
-    SpanRequest spanRequest = new DefaultSpanRequest(null, resultSetRequest, logAttributeRequests);
+    SpanRequest spanRequest =
+        new DefaultSpanRequest(null, resultSetRequest, logAttributeRequests, true);
 
     LogEventsRequest expectedLogEventsRequest =
         LogEventsRequest.newBuilder()
@@ -193,7 +194,8 @@ class SpanLogEventRequestBuilderTest {
             List.of(),
             Collections.emptyList(),
             Optional.empty());
-    SpanRequest spanRequest = new DefaultSpanRequest(null, resultSetRequest, logAttributeRequests);
+    SpanRequest spanRequest =
+        new DefaultSpanRequest(null, resultSetRequest, logAttributeRequests, true);
 
     LogEventsRequest expectedLogEventsRequest =
         LogEventsRequest.newBuilder()

--- a/hypertrace-core-graphql-trace-schema/build.gradle.kts
+++ b/hypertrace-core-graphql-trace-schema/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
   implementation(project(":hypertrace-core-graphql-attribute-store"))
   implementation(project(":hypertrace-core-graphql-deserialization"))
   implementation(project(":hypertrace-core-graphql-request-transformation"))
+  implementation(project(":hypertrace-core-graphql-schema-utils"))
 }

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceConverter.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceConverter.java
@@ -30,8 +30,7 @@ public class GatewayServiceTraceConverter {
   }
 
   public Single<TraceResultSet> convert(ResultSetRequest<?> request, TracesResponse response) {
-    int total = response.getTotal();
-
+    int total = response.hasTotal() ? response.getTotal() : 0;
     return Observable.fromIterable(response.getTracesList())
         .flatMapSingle(trace -> this.convert(request, trace))
         .toList()

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceRequestBuilder.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceRequestBuilder.java
@@ -54,6 +54,7 @@ class GatewayServiceTraceRequestBuilder {
                 .setFilter(filters)
                 .setSpaceId(
                     request.resultSetRequest().spaceId().orElse("")) // String proto default value
+                .setFetchTotal(request.fetchTotal())
                 .build());
   }
 }

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/request/DefaultTraceRequestBuilder.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/request/DefaultTraceRequestBuilder.java
@@ -8,22 +8,29 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import org.hypertrace.core.graphql.common.request.ResultSetRequest;
 import org.hypertrace.core.graphql.common.request.ResultSetRequestBuilder;
+import org.hypertrace.core.graphql.common.schema.results.ResultSet;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.deserialization.ArgumentDeserializer;
 import org.hypertrace.core.graphql.trace.schema.arguments.TraceType;
 import org.hypertrace.core.graphql.trace.schema.arguments.TraceTypeArgument;
+import org.hypertrace.core.graphql.utils.schema.GraphQlSelectionFinder;
+import org.hypertrace.core.graphql.utils.schema.SelectionQuery;
 
 class DefaultTraceRequestBuilder implements TraceRequestBuilder {
 
   private final ResultSetRequestBuilder resultSetRequestBuilder;
   private final ArgumentDeserializer argumentDeserializer;
+  private final GraphQlSelectionFinder selectionFinder;
 
   @Inject
   DefaultTraceRequestBuilder(
-      ResultSetRequestBuilder resultSetRequestBuilder, ArgumentDeserializer argumentDeserializer) {
+      ResultSetRequestBuilder resultSetRequestBuilder,
+      ArgumentDeserializer argumentDeserializer,
+      GraphQlSelectionFinder selectionFinder) {
     this.resultSetRequestBuilder = resultSetRequestBuilder;
     this.argumentDeserializer = argumentDeserializer;
+    this.selectionFinder = selectionFinder;
   }
 
   @Override
@@ -37,18 +44,28 @@ class DefaultTraceRequestBuilder implements TraceRequestBuilder {
             .deserializePrimitive(arguments, TraceTypeArgument.class)
             .orElseThrow();
 
-    return this.build(context, traceType, arguments, selectionSet);
+    boolean fetchTotal =
+        this.selectionFinder
+                .findSelections(
+                    selectionSet, SelectionQuery.namedChild(ResultSet.RESULT_SET_TOTAL_NAME))
+                .count()
+            > 0;
+
+    return this.build(context, traceType, arguments, selectionSet, fetchTotal);
   }
 
   private Single<TraceRequest> build(
       GraphQlRequestContext context,
       TraceType traceType,
       Map<String, Object> arguments,
-      DataFetchingFieldSelectionSet selectionSet) {
+      DataFetchingFieldSelectionSet selectionSet,
+      boolean fetchTotal) {
 
     return this.resultSetRequestBuilder
         .build(context, traceType.getScopeString(), arguments, selectionSet)
-        .map(resultSetRequest -> new DefaultTraceRequest(context, resultSetRequest, traceType));
+        .map(
+            resultSetRequest ->
+                new DefaultTraceRequest(context, resultSetRequest, traceType, fetchTotal));
   }
 
   @Value
@@ -57,5 +74,6 @@ class DefaultTraceRequestBuilder implements TraceRequestBuilder {
     GraphQlRequestContext context;
     ResultSetRequest<OrderArgument> resultSetRequest;
     TraceType traceType;
+    boolean fetchTotal;
   }
 }

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/request/TraceRequest.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/request/TraceRequest.java
@@ -9,4 +9,6 @@ public interface TraceRequest extends ContextualRequest {
   ResultSetRequest<OrderArgument> resultSetRequest();
 
   TraceType traceType();
+
+  boolean fetchTotal();
 }

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -15,7 +15,7 @@
     <packageUrl regex="true">^pkg:maven/io\.github\.graphql\-java/graphql\-java\-annotations@.*$</packageUrl>
     <cpe>cpe:/a:graphql-java:graphql-java</cpe>
   </suppress>
-  <suppress until="2023-06-29Z">
+  <suppress until="2023-07-30Z">
     <notes><![CDATA[
    file name: jackson-databind-2.15.2.jar
    ]]></notes>


### PR DESCRIPTION
## Description
As part of supporting `fetch_total` as request in spans/traces API, this PR makes the corresponding changes at client side.

Ref PR: https://github.com/hypertrace/gateway-service/pull/169
