### PR TITLE
feat: add support for logical operators

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/DefaultResultSetRequestBuilder.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/DefaultResultSetRequestBuilder.java
@@ -20,6 +20,8 @@ import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.ResultSet;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperatorArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.LimitArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.OffsetArgument;
@@ -89,6 +91,11 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
             .deserializeObjectList(arguments, orderArgumentClass)
             .orElse(Collections.emptyList());
 
+    LogicalFilterOperator logicalFilterOperator =
+        this.argumentDeserializer
+            .deserializePrimitive(arguments, LogicalFilterOperatorArgument.class)
+            .orElse(LogicalFilterOperator.AND);
+
     List<FilterArgument> requestedFilters =
         this.argumentDeserializer
             .deserializeObjectList(arguments, FilterArgument.class)
@@ -114,6 +121,7 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
                     offset,
                     timeRange,
                     orders,
+                    logicalFilterOperator,
                     filters,
                     this.getAttributeQueryableFields(selectionSet),
                     spaceId))
@@ -128,6 +136,7 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
       int offset,
       TimeRangeArgument timeRange,
       List<AttributeAssociation<O>> orderArguments,
+      LogicalFilterOperator logicalFilterOperator,
       Collection<AttributeAssociation<FilterArgument>> filterArguments,
       Stream<SelectedField> attributeQueryableFields,
       Optional<String> spaceId) {
@@ -145,6 +154,7 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
                 limit,
                 offset,
                 orderArguments,
+                logicalFilterOperator,
                 filterArguments,
                 spaceId));
   }
@@ -184,6 +194,7 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
                 limit,
                 0,
                 List.of(),
+                LogicalFilterOperator.AND,
                 filters,
                 Optional.empty()));
   }
@@ -206,6 +217,7 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
                     originalRequest.limit(),
                     originalRequest.offset(),
                     originalRequest.orderArguments(),
+                    originalRequest.logicalFilterOperator(),
                     mergedFilters,
                     originalRequest.spaceId()));
   }
@@ -251,6 +263,7 @@ class DefaultResultSetRequestBuilder implements ResultSetRequestBuilder {
     int limit;
     int offset;
     List<AttributeAssociation<O>> orderArguments;
+    LogicalFilterOperator logicalFilterOperator;
     Collection<AttributeAssociation<FilterArgument>> filterArguments;
     Optional<String> spaceId;
   }

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequest.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 
 public interface ResultSetRequest<O extends OrderArgument> extends ContextualRequest {
@@ -23,6 +24,8 @@ public interface ResultSetRequest<O extends OrderArgument> extends ContextualReq
   List<AttributeAssociation<O>> orderArguments();
 
   Collection<AttributeAssociation<FilterArgument>> filterArguments();
+
+  LogicalFilterOperator logicalFilterOperator();
 
   Optional<String> spaceId();
 }

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequestBuilder.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/request/ResultSetRequestBuilder.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 
@@ -35,6 +36,7 @@ public interface ResultSetRequestBuilder {
       int offset,
       TimeRangeArgument timeRange,
       List<AttributeAssociation<O>> orderArguments,
+      LogicalFilterOperator logicalFilterOperator,
       Collection<AttributeAssociation<FilterArgument>> filterArguments,
       Stream<SelectedField> attributeQueryableFields,
       Optional<String> spaceId);

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/LogicalFilterOperator.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/LogicalFilterOperator.java
@@ -1,0 +1,11 @@
+package org.hypertrace.core.graphql.common.schema.results.arguments.filter;
+
+import graphql.annotations.annotationTypes.GraphQLName;
+
+@GraphQLName(LogicalFilterOperator.TYPE_NAME)
+public enum LogicalFilterOperator {
+  AND,
+  OR;
+
+  static final String TYPE_NAME = "LogicalFilterOperator";
+}

--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/LogicalFilterOperatorArgument.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/results/arguments/filter/LogicalFilterOperatorArgument.java
@@ -1,0 +1,8 @@
+package org.hypertrace.core.graphql.common.schema.results.arguments.filter;
+
+import org.hypertrace.core.graphql.deserialization.PrimitiveArgument;
+
+public interface LogicalFilterOperatorArgument extends PrimitiveArgument<LogicalFilterOperator> {
+
+  String ARGUMENT_NAME = "logicalOperator";
+}

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/request/DefaultResultSetRequestBuilderTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/request/DefaultResultSetRequestBuilderTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import org.hypertrace.core.graphql.attributes.AttributeModel;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperatorArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.LimitArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.OffsetArgument;
@@ -94,6 +95,9 @@ class DefaultResultSetRequestBuilderTest {
         .thenReturn(Optional.of(List.of(this.mockFilterArgument)));
     when(this.mockArgumentDeserializer.deserializePrimitive(any(), eq(SpaceArgument.class)))
         .thenReturn(Optional.of(this.mockSpace));
+    when(this.mockArgumentDeserializer.deserializePrimitive(
+            any(), eq(LogicalFilterOperatorArgument.class)))
+        .thenReturn(Optional.empty());
 
     ResultSetRequest<OrderArgument> request =
         this.requestBuilder

--- a/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/GatewayUtilsModule.java
+++ b/hypertrace-core-graphql-gateway-service-utils/src/main/java/org/hypertrace/core/graphql/utils/gateway/GatewayUtilsModule.java
@@ -14,6 +14,7 @@ import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterOperatorType;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection;
 import org.hypertrace.core.graphql.common.utils.BiConverter;
@@ -57,6 +58,13 @@ public class GatewayUtilsModule extends AbstractModule {
     bind(Key.get(
             new TypeLiteral<
                 Converter<Collection<AttributeAssociation<FilterArgument>>, Filter>>() {}))
+        .to(FilterConverter.class);
+    bind(Key.get(
+            new TypeLiteral<
+                BiConverter<
+                    Collection<AttributeAssociation<FilterArgument>>,
+                    LogicalFilterOperator,
+                    Filter>>() {}))
         .to(FilterConverter.class);
 
     bind(Key.get(new TypeLiteral<Converter<AttributeModel, ColumnIdentifier>>() {}))

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventsRequestBuilder.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventsRequestBuilder.java
@@ -7,10 +7,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
+import lombok.RequiredArgsConstructor;
 import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
+import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.core.graphql.log.event.request.LogEventRequest;
 import org.hypertrace.gateway.service.v1.common.Expression;
@@ -18,28 +21,21 @@ import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.log.events.LogEventsRequest;
 
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 class GatewayServiceLogEventsRequestBuilder {
-
-  private final Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter;
+  private final BiConverter<
+          Collection<AttributeAssociation<FilterArgument>>, LogicalFilterOperator, Filter>
+      filterConverter;
   private final Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>>
       orderConverter;
   private final Converter<Collection<AttributeRequest>, Set<Expression>> attributeConverter;
-
-  @Inject
-  GatewayServiceLogEventsRequestBuilder(
-      Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter,
-      Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>> orderConverter,
-      Converter<Collection<AttributeRequest>, Set<Expression>> attributeConverter) {
-    this.filterConverter = filterConverter;
-    this.orderConverter = orderConverter;
-    this.attributeConverter = attributeConverter;
-  }
 
   Single<LogEventsRequest> buildRequest(LogEventRequest gqlRequest) {
     return zip(
         this.attributeConverter.convert(gqlRequest.attributes()),
         this.orderConverter.convert(gqlRequest.orderArguments()),
-        this.filterConverter.convert(gqlRequest.filterArguments()),
+        this.filterConverter.convert(
+            gqlRequest.filterArguments(), gqlRequest.logicalFilterOperator()),
         (selections, orderBys, filters) ->
             LogEventsRequest.newBuilder()
                 .setStartTimeMillis(gqlRequest.timeRange().startTime().toEpochMilli())

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/LogEventDaoModule.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/dao/LogEventDaoModule.java
@@ -12,6 +12,7 @@ import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
@@ -46,7 +47,10 @@ public class LogEventDaoModule extends AbstractModule {
     requireBinding(
         Key.get(
             new TypeLiteral<
-                Converter<Collection<AttributeAssociation<FilterArgument>>, Filter>>() {}));
+                BiConverter<
+                    Collection<AttributeAssociation<FilterArgument>>,
+                    LogicalFilterOperator,
+                    Filter>>() {}));
 
     requireBinding(
         Key.get(

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/request/DefaultLogEventRequestBuilder.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/request/DefaultLogEventRequestBuilder.java
@@ -22,6 +22,8 @@ import org.hypertrace.core.graphql.common.request.FilterRequestBuilder;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.ResultSet;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperatorArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.LimitArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.OffsetArgument;
@@ -94,6 +96,11 @@ public class DefaultLogEventRequestBuilder implements LogEventRequestBuilder {
             .deserializeObjectList(arguments, orderArgumentClass)
             .orElse(Collections.emptyList());
 
+    LogicalFilterOperator filterOperator =
+        this.argumentDeserializer
+            .deserializePrimitive(arguments, LogicalFilterOperatorArgument.class)
+            .orElse(LogicalFilterOperator.AND);
+
     List<FilterArgument> requestedFilters =
         this.argumentDeserializer
             .deserializeObjectList(arguments, FilterArgument.class)
@@ -115,7 +122,14 @@ public class DefaultLogEventRequestBuilder implements LogEventRequestBuilder {
             (attributeRequests, orders, filters) ->
                 Single.just(
                     new DefaultLogEventRequest(
-                        context, attributeRequests, timeRange, limit, offset, orders, filters)))
+                        context,
+                        attributeRequests,
+                        timeRange,
+                        limit,
+                        offset,
+                        orders,
+                        filterOperator,
+                        filters)))
         .flatMap(single -> single);
   }
 
@@ -135,6 +149,7 @@ public class DefaultLogEventRequestBuilder implements LogEventRequestBuilder {
     int limit;
     int offset;
     List<AttributeAssociation<OrderArgument>> orderArguments;
+    LogicalFilterOperator logicalFilterOperator;
     Collection<AttributeAssociation<FilterArgument>> filterArguments;
   }
 }

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/request/LogEventRequest.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/request/LogEventRequest.java
@@ -7,6 +7,7 @@ import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.request.ContextualRequest;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 
 public interface LogEventRequest extends ContextualRequest {
@@ -20,6 +21,8 @@ public interface LogEventRequest extends ContextualRequest {
   int offset();
 
   List<AttributeAssociation<OrderArgument>> orderArguments();
+
+  LogicalFilterOperator logicalFilterOperator();
 
   Collection<AttributeAssociation<FilterArgument>> filterArguments();
 }

--- a/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/schema/LogEventSchema.java
+++ b/hypertrace-core-graphql-log-event-schema/src/main/java/org/hypertrace/core/graphql/log/event/schema/LogEventSchema.java
@@ -7,6 +7,8 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import java.util.List;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperatorArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.LimitArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.OffsetArgument;
@@ -21,6 +23,8 @@ public interface LogEventSchema {
   @GraphQLDataFetcher(LogEventFetcher.class)
   LogEventResultSet logEvents(
       @GraphQLName(TimeRangeArgument.ARGUMENT_NAME) @GraphQLNonNull TimeRangeArgument between,
+      @GraphQLName(LogicalFilterOperatorArgument.ARGUMENT_NAME)
+          LogicalFilterOperator logicalFilterOperator,
       @GraphQLName(FilterArgument.ARGUMENT_NAME) List<FilterArgument> filterBy,
       @GraphQLName(OrderArgument.ARGUMENT_NAME) List<OrderArgument> orderBy,
       @GraphQLName(LimitArgument.ARGUMENT_NAME) int limit,

--- a/hypertrace-core-graphql-log-event-schema/src/test/java/org/hypertrace/core/graphql/log/event/dao/BaseDaoTest.java
+++ b/hypertrace-core-graphql-log-event-schema/src/test/java/org/hypertrace/core/graphql/log/event/dao/BaseDaoTest.java
@@ -14,6 +14,7 @@ import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.log.event.request.LogEventRequest;
@@ -30,6 +31,7 @@ class BaseDaoTest {
     int limit;
     int offset;
     List<AttributeAssociation<OrderArgument>> orderArguments;
+    LogicalFilterOperator logicalFilterOperator;
     Collection<AttributeAssociation<FilterArgument>> filterArguments;
   }
 

--- a/hypertrace-core-graphql-log-event-schema/src/test/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventsRequestBuilderTest.java
+++ b/hypertrace-core-graphql-log-event-schema/src/test/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventsRequestBuilderTest.java
@@ -20,7 +20,9 @@ import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
+import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
 import org.hypertrace.core.graphql.utils.gateway.GatewayUtilsModule;
@@ -50,11 +52,15 @@ class GatewayServiceLogEventsRequestBuilderTest extends BaseDaoTest {
               }
             });
 
-    Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter =
-        injector.getInstance(
-            Key.get(
-                new TypeLiteral<
-                    Converter<Collection<AttributeAssociation<FilterArgument>>, Filter>>() {}));
+    BiConverter<Collection<AttributeAssociation<FilterArgument>>, LogicalFilterOperator, Filter>
+        filterConverter =
+            injector.getInstance(
+                Key.get(
+                    new TypeLiteral<
+                        BiConverter<
+                            Collection<AttributeAssociation<FilterArgument>>,
+                            LogicalFilterOperator,
+                            Filter>>() {}));
     Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>> orderConverter =
         injector.getInstance(
             Key.get(
@@ -115,6 +121,7 @@ class GatewayServiceLogEventsRequestBuilderTest extends BaseDaoTest {
             0,
             0,
             List.of(),
+            LogicalFilterOperator.AND,
             Collections.emptyList());
     LogEventsRequest logEventRequest =
         requestBuilder.buildRequest(defaultLogEventRequest).blockingGet();

--- a/hypertrace-core-graphql-log-event-schema/src/test/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventsResponseConverterTest.java
+++ b/hypertrace-core-graphql-log-event-schema/src/test/java/org/hypertrace/core/graphql/log/event/dao/GatewayServiceLogEventsResponseConverterTest.java
@@ -19,6 +19,7 @@ import org.hypertrace.core.graphql.attributes.AttributeModelType;
 import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.log.event.schema.LogEventResultSet;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
@@ -121,6 +122,7 @@ class GatewayServiceLogEventsResponseConverterTest extends BaseDaoTest {
             0,
             0,
             List.of(),
+            LogicalFilterOperator.AND,
             Collections.emptyList());
     LogEventResultSet logEventResultSet =
         responseConverter.convert(defaultLogEventRequest, logEventsResponse).blockingGet();

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanRequestBuilder.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/GatewayServiceSpanRequestBuilder.java
@@ -7,10 +7,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
+import lombok.RequiredArgsConstructor;
 import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
+import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.core.graphql.span.request.SpanRequest;
 import org.hypertrace.gateway.service.v1.common.Expression;
@@ -18,28 +21,23 @@ import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.span.SpansRequest;
 
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 class GatewayServiceSpanRequestBuilder {
 
-  private final Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter;
+  private final BiConverter<
+          Collection<AttributeAssociation<FilterArgument>>, LogicalFilterOperator, Filter>
+      filterConverter;
   private final Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>>
       orderConverter;
   private final Converter<Collection<AttributeRequest>, Set<Expression>> attributeConverter;
-
-  @Inject
-  GatewayServiceSpanRequestBuilder(
-      Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter,
-      Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>> orderConverter,
-      Converter<Collection<AttributeRequest>, Set<Expression>> attributeConverter) {
-    this.filterConverter = filterConverter;
-    this.orderConverter = orderConverter;
-    this.attributeConverter = attributeConverter;
-  }
 
   Single<SpansRequest> buildRequest(SpanRequest gqlRequest) {
     return zip(
         this.attributeConverter.convert(gqlRequest.spanEventsRequest().attributes()),
         this.orderConverter.convert(gqlRequest.spanEventsRequest().orderArguments()),
-        this.filterConverter.convert(gqlRequest.spanEventsRequest().filterArguments()),
+        this.filterConverter.convert(
+            gqlRequest.spanEventsRequest().filterArguments(),
+            gqlRequest.spanEventsRequest().logicalFilterOperator()),
         (selections, orderBys, filters) ->
             SpansRequest.newBuilder()
                 .setStartTimeMillis(

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanDaoModule.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/dao/SpanDaoModule.java
@@ -15,6 +15,7 @@ import org.hypertrace.core.graphql.common.request.AttributeRequestBuilder;
 import org.hypertrace.core.graphql.common.request.FilterRequestBuilder;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
@@ -58,7 +59,10 @@ public class SpanDaoModule extends AbstractModule {
     requireBinding(
         Key.get(
             new TypeLiteral<
-                Converter<Collection<AttributeAssociation<FilterArgument>>, Filter>>() {}));
+                BiConverter<
+                    Collection<AttributeAssociation<FilterArgument>>,
+                    LogicalFilterOperator,
+                    Filter>>() {}));
 
     requireBinding(
         Key.get(

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/schema/SpanSchema.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/schema/SpanSchema.java
@@ -7,6 +7,8 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import java.util.List;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperatorArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.LimitArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.OffsetArgument;
@@ -24,6 +26,8 @@ public interface SpanSchema {
   @GraphQLDataFetcher(SpanFetcher.class)
   SpanResultSet spans(
       @GraphQLName(TimeRangeArgument.ARGUMENT_NAME) @GraphQLNonNull TimeRangeArgument between,
+      @GraphQLName(LogicalFilterOperatorArgument.ARGUMENT_NAME)
+          LogicalFilterOperator logicalFilterOperator,
       @GraphQLName(FilterArgument.ARGUMENT_NAME) List<FilterArgument> filterBy,
       @GraphQLName(OrderArgument.ARGUMENT_NAME) List<OrderArgument> orderBy,
       @GraphQLName(LimitArgument.ARGUMENT_NAME) int limit,
@@ -36,6 +40,8 @@ public interface SpanSchema {
   @GraphQLDataFetcher(ExportSpanFetcher.class)
   ExportSpanResult exportSpans(
       @GraphQLName(TimeRangeArgument.ARGUMENT_NAME) @GraphQLNonNull TimeRangeArgument between,
+      @GraphQLName(LogicalFilterOperatorArgument.ARGUMENT_NAME)
+          LogicalFilterOperator logicalFilterOperator,
       @GraphQLName(FilterArgument.ARGUMENT_NAME) List<FilterArgument> filterBy,
       @GraphQLName(LimitArgument.ARGUMENT_NAME) int limit);
 }

--- a/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/DaoTestUtil.java
+++ b/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/DaoTestUtil.java
@@ -21,6 +21,7 @@ import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeE
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterOperatorType;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterType;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.span.request.SpanRequest;
@@ -85,6 +86,7 @@ class DaoTestUtil {
     int limit;
     int offset;
     List<AttributeAssociation<OrderArgument>> orderArguments;
+    LogicalFilterOperator logicalFilterOperator;
     Collection<AttributeAssociation<FilterArgument>> filterArguments;
     Optional<String> spaceId;
   }

--- a/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/SpanLogEventRequestBuilderTest.java
+++ b/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/dao/SpanLogEventRequestBuilderTest.java
@@ -36,6 +36,7 @@ import org.hypertrace.core.graphql.common.request.AttributeRequestBuilder;
 import org.hypertrace.core.graphql.common.request.FilterRequestBuilder;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.core.graphql.span.dao.DaoTestUtil.DefaultAttributeRequest;
 import org.hypertrace.core.graphql.span.dao.DaoTestUtil.DefaultResultSetRequest;
@@ -150,6 +151,7 @@ class SpanLogEventRequestBuilderTest {
             0,
             0,
             List.of(),
+            LogicalFilterOperator.AND,
             Collections.emptyList(),
             Optional.empty());
     SpanRequest spanRequest =
@@ -192,6 +194,7 @@ class SpanLogEventRequestBuilderTest {
             0,
             0,
             List.of(),
+            LogicalFilterOperator.AND,
             Collections.emptyList(),
             Optional.empty());
     SpanRequest spanRequest =

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceRequestBuilder.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/GatewayServiceTraceRequestBuilder.java
@@ -7,10 +7,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
+import lombok.RequiredArgsConstructor;
 import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
+import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.core.graphql.trace.request.TraceRequest;
 import org.hypertrace.gateway.service.v1.common.Expression;
@@ -18,29 +21,23 @@ import org.hypertrace.gateway.service.v1.common.Filter;
 import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.trace.TracesRequest;
 
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 class GatewayServiceTraceRequestBuilder {
-
-  private final Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter;
+  private final BiConverter<
+          Collection<AttributeAssociation<FilterArgument>>, LogicalFilterOperator, Filter>
+      filterConverter;
   private final Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>>
       orderConverter;
   private final Converter<Collection<AttributeRequest>, Set<Expression>> selectionConverter;
-
-  @Inject
-  GatewayServiceTraceRequestBuilder(
-      Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter,
-      Converter<List<AttributeAssociation<OrderArgument>>, List<OrderByExpression>> orderConverter,
-      Converter<Collection<AttributeRequest>, Set<Expression>> selectionConverter) {
-    this.filterConverter = filterConverter;
-    this.orderConverter = orderConverter;
-    this.selectionConverter = selectionConverter;
-  }
 
   Single<TracesRequest> buildRequest(TraceRequest request) {
 
     return zip(
         this.selectionConverter.convert(request.resultSetRequest().attributes()),
         this.orderConverter.convert(request.resultSetRequest().orderArguments()),
-        this.filterConverter.convert(request.resultSetRequest().filterArguments()),
+        this.filterConverter.convert(
+            request.resultSetRequest().filterArguments(),
+            request.resultSetRequest().logicalFilterOperator()),
         (selections, orderBys, filters) ->
             TracesRequest.newBuilder()
                 .setScope(request.traceType().getScopeString())

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/TraceDaoModule.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/dao/TraceDaoModule.java
@@ -12,6 +12,7 @@ import org.hypertrace.core.graphql.common.request.AttributeAssociation;
 import org.hypertrace.core.graphql.common.request.AttributeRequest;
 import org.hypertrace.core.graphql.common.schema.attributes.arguments.AttributeExpression;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.utils.BiConverter;
 import org.hypertrace.core.graphql.common.utils.Converter;
@@ -47,7 +48,10 @@ public class TraceDaoModule extends AbstractModule {
     requireBinding(
         Key.get(
             new TypeLiteral<
-                Converter<Collection<AttributeAssociation<FilterArgument>>, Filter>>() {}));
+                BiConverter<
+                    Collection<AttributeAssociation<FilterArgument>>,
+                    LogicalFilterOperator,
+                    Filter>>() {}));
 
     requireBinding(
         Key.get(

--- a/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/schema/TraceSchema.java
+++ b/hypertrace-core-graphql-trace-schema/src/main/java/org/hypertrace/core/graphql/trace/schema/TraceSchema.java
@@ -7,6 +7,8 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import java.util.List;
 import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperator;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.LogicalFilterOperatorArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.LimitArgument;
 import org.hypertrace.core.graphql.common.schema.results.arguments.page.OffsetArgument;
@@ -25,6 +27,8 @@ public interface TraceSchema {
   TraceResultSet traces(
       @Deprecated @GraphQLName(TraceTypeArgument.ARGUMENT_NAME) TraceType type,
       @GraphQLName(TimeRangeArgument.ARGUMENT_NAME) @GraphQLNonNull TimeRangeArgument between,
+      @GraphQLName(LogicalFilterOperatorArgument.ARGUMENT_NAME)
+          LogicalFilterOperator logicalFilterOperator,
       @GraphQLName(FilterArgument.ARGUMENT_NAME) List<FilterArgument> filterBy,
       @GraphQLName(OrderArgument.ARGUMENT_NAME) List<OrderArgument> orderBy,
       @GraphQLName(LimitArgument.ARGUMENT_NAME) int limit,


### PR DESCRIPTION
## Description

Add support for specifying a logical operator at the top level of a request. Previously it had defaulted to always be AND. 
