### PR TITLE
fix: add support for deserializing zoned expressions

### DIFF
--- a/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/DateTimeScalar.java
+++ b/hypertrace-core-graphql-common-schema/src/main/java/org/hypertrace/core/graphql/common/schema/typefunctions/DateTimeScalar.java
@@ -12,6 +12,7 @@ import graphql.schema.GraphQLScalarType;
 import java.lang.reflect.AnnotatedType;
 import java.time.DateTimeException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.function.Function;
 
@@ -45,10 +46,10 @@ public class DateTimeScalar implements TypeFunction {
                       return Instant.from((TemporalAccessor) instantInput);
                     }
                     if (instantInput instanceof CharSequence) {
-                      return Instant.parse((CharSequence) instantInput);
+                      return parse((CharSequence) instantInput);
                     }
                     if (instantInput instanceof StringValue) {
-                      return Instant.parse(((StringValue) instantInput).getValue());
+                      return parse(((StringValue) instantInput).getValue());
                     }
                   } catch (DateTimeException exception) {
                     throw errorWrapper.apply(exception);
@@ -74,5 +75,9 @@ public class DateTimeScalar implements TypeFunction {
       AnnotatedType annotatedType,
       ProcessingElementsContainer container) {
     return DATE_TIME_SCALAR;
+  }
+
+  private static Instant parse(CharSequence charSequence) {
+    return OffsetDateTime.parse(charSequence).toInstant();
   }
 }

--- a/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/DateTimeScalarTest.java
+++ b/hypertrace-core-graphql-common-schema/src/test/java/org/hypertrace/core/graphql/common/schema/scalars/DateTimeScalarTest.java
@@ -19,8 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DateTimeScalarTest {
 
-  private static final String TEST_DATE_TIME_STRING = "2019-10-29T21:30:12.871Z";
-  private static final Instant TEST_DATE_TIME_INSTANT = Instant.parse(TEST_DATE_TIME_STRING);
+  private static final String TEST_UTC_DATE_TIME_STRING = "2019-10-29T21:30:12.871Z";
+  private static final String TEST_ZONED_DATE_TIME_STRING = "2019-10-30T03:00:12.871+05:30";
+  private static final Instant TEST_DATE_TIME_INSTANT = Instant.parse(TEST_UTC_DATE_TIME_STRING);
   private DateTimeScalar dateTimeFunction;
   private GraphQLScalarType dateTimeType;
   @Mock AnnotatedType mockAnnotatedType;
@@ -45,18 +46,24 @@ class DateTimeScalarTest {
   @Test
   void canConvertFromLiteral() {
     assertEquals(
-        TEST_DATE_TIME_INSTANT, dateTimeType.getCoercing().parseLiteral(TEST_DATE_TIME_STRING));
+        TEST_DATE_TIME_INSTANT, dateTimeType.getCoercing().parseLiteral(TEST_UTC_DATE_TIME_STRING));
+    assertEquals(
+        TEST_DATE_TIME_INSTANT,
+        dateTimeType.getCoercing().parseLiteral(TEST_ZONED_DATE_TIME_STRING));
   }
 
   @Test
   void canSerialize() {
     assertEquals(
-        TEST_DATE_TIME_STRING, dateTimeType.getCoercing().serialize(TEST_DATE_TIME_INSTANT));
+        TEST_UTC_DATE_TIME_STRING, dateTimeType.getCoercing().serialize(TEST_DATE_TIME_INSTANT));
     assertEquals(
-        TEST_DATE_TIME_STRING, dateTimeType.getCoercing().serialize(TEST_DATE_TIME_STRING));
+        TEST_UTC_DATE_TIME_STRING, dateTimeType.getCoercing().serialize(TEST_UTC_DATE_TIME_STRING));
+    assertEquals(
+        TEST_UTC_DATE_TIME_STRING,
+        dateTimeType.getCoercing().serialize(TEST_ZONED_DATE_TIME_STRING));
 
     assertEquals(
-        TEST_DATE_TIME_STRING,
+        TEST_UTC_DATE_TIME_STRING,
         dateTimeType
             .getCoercing()
             .serialize(TEST_DATE_TIME_INSTANT.atOffset(ZoneOffset.ofHoursMinutes(12, 30))));
@@ -68,6 +75,11 @@ class DateTimeScalarTest {
         TEST_DATE_TIME_INSTANT,
         dateTimeType
             .getCoercing()
-            .parseValue(StringValue.newStringValue().value(TEST_DATE_TIME_STRING).build()));
+            .parseValue(StringValue.newStringValue().value(TEST_UTC_DATE_TIME_STRING).build()));
+    assertEquals(
+        TEST_DATE_TIME_INSTANT,
+        dateTimeType
+            .getCoercing()
+            .parseValue(StringValue.newStringValue().value(TEST_ZONED_DATE_TIME_STRING).build()));
   }
 }


### PR DESCRIPTION
## Description
Adds support for accepting zoned date time strings. Previously only accepted UTC, but could return a UTC from either zoned or UTC.