### PR TITLE
chore | Add support for selecting spanSource as DomainEventSpanView or SpanEventView in span join

### DIFF
--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/joiner/SpanJoiner.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/joiner/SpanJoiner.java
@@ -16,21 +16,26 @@ public interface SpanJoiner {
       new SpanJoiner() {
         @Override
         public <T> Single<Map<T, Span>> joinSpan(
-            Collection<T> joinSources, SpanIdGetter<T> spanIdGetter) {
+            Collection<T> joinSources, SpanIdGetter<T> spanIdGetter, SpanSource spanSource) {
           return Single.just(Collections.emptyMap());
         }
 
         @Override
         public <T> Single<ListMultimap<T, Span>> joinSpans(
-            Collection<T> joinSources, MultipleSpanIdGetter<T> multipleSpanIdGetter) {
+            Collection<T> joinSources,
+            MultipleSpanIdGetter<T> multipleSpanIdGetter,
+            SpanSource spanSource) {
           return Single.just(ArrayListMultimap.create());
         }
       };
 
-  <T> Single<Map<T, Span>> joinSpan(Collection<T> joinSources, SpanIdGetter<T> spanIdGetter);
+  <T> Single<Map<T, Span>> joinSpan(
+      Collection<T> joinSources, SpanIdGetter<T> spanIdGetter, SpanSource spanSource);
 
   <T> Single<ListMultimap<T, Span>> joinSpans(
-      Collection<T> joinSources, MultipleSpanIdGetter<T> multipleSpanIdGetter);
+      Collection<T> joinSources,
+      MultipleSpanIdGetter<T> multipleSpanIdGetter,
+      SpanSource spanSource);
 
   @FunctionalInterface
   interface SpanIdGetter<T> {

--- a/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/joiner/SpanSource.java
+++ b/hypertrace-core-graphql-span-schema/src/main/java/org/hypertrace/core/graphql/span/joiner/SpanSource.java
@@ -1,0 +1,7 @@
+package org.hypertrace.core.graphql.span.joiner;
+
+public enum SpanSource {
+  SPAN_EVENT_VIEW,
+  DOMAIN_EVENT_SPAN_VIEW,
+  ;
+}

--- a/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/joiner/SpanJoinerBuilderTest.java
+++ b/hypertrace-core-graphql-span-schema/src/test/java/org/hypertrace/core/graphql/span/joiner/SpanJoinerBuilderTest.java
@@ -3,6 +3,8 @@ package org.hypertrace.core.graphql.span.joiner;
 import static java.util.Collections.emptyList;
 import static java.util.Map.entry;
 import static org.hypertrace.core.graphql.atttributes.scopes.HypertraceCoreAttributeScopeString.SPAN;
+import static org.hypertrace.core.graphql.span.joiner.SpanSource.DOMAIN_EVENT_SPAN_VIEW;
+import static org.hypertrace.core.graphql.span.joiner.SpanSource.SPAN_EVENT_VIEW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -112,7 +114,8 @@ public class SpanJoinerBuilderTest {
                 List.of("pathToSpan"))
             .blockingGet();
     assertEquals(
-        expected, joiner.joinSpan(joinSources, new TestJoinSourceIdGetter()).blockingGet());
+        expected,
+        joiner.joinSpan(joinSources, new TestJoinSourceIdGetter(), SPAN_EVENT_VIEW).blockingGet());
   }
 
   @Test
@@ -155,7 +158,9 @@ public class SpanJoinerBuilderTest {
             .blockingGet();
     assertEquals(
         expected,
-        joiner.joinSpans(joinSources, new TestMultipleJoinSourceIdGetter()).blockingGet());
+        joiner
+            .joinSpans(joinSources, new TestMultipleJoinSourceIdGetter(), DOMAIN_EVENT_SPAN_VIEW)
+            .blockingGet());
   }
 
   private void mockResult(List<Span> spans) {


### PR DESCRIPTION


## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
